### PR TITLE
Add check to make sure PR title matches commit message when only one commit

### DIFF
--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -8,6 +8,7 @@ const { getAmplifyURI, getStorybookAmplifyUri } = require("./amplify");
 exports.validatePR = async function validatePR({ pullRequest }) {
   const {
     number: pullNumber,
+    commits,
     base: {
       ref: baseRef,
       repo: {
@@ -15,7 +16,7 @@ exports.validatePR = async function validatePR({ pullRequest }) {
         name: repo,
       },
     },
-    head: { ref: headRef },
+    head: { ref: headRef, sha: headSha },
     title,
   } = pullRequest;
 
@@ -72,6 +73,26 @@ exports.validatePR = async function validatePR({ pullRequest }) {
     throw new Error(
       `This pull request is based on the branch “${headRef}”, which starts like “${nokBranch}”. Use double dashes (“--”) to separate sub-branches. See https://app.gitbook.com/@mobsuccess/s/mobsuccess/git`
     );
+  }
+
+  if (commits === 1) {
+    // we have only one commit, make sure its name match the name of the PR
+    const {
+      data: { message: commitMessage },
+    } = await octokit.rest.git.getCommit({
+      owner,
+      repo,
+      commit_sha: headSha,
+    });
+    if (commitMessage !== title) {
+      throw new Error(
+        `This pull request has only one commit, and its message doesn't match the title of the PR. If you'd like to keep the title of the PR as it is, please add an empty commit.`
+      );
+    } else {
+      console.log(
+        "This pull request has only one commit, and its message matches the title of the PR."
+      );
+    }
   }
 
   // everything seems valid: add the label if it exists


### PR DESCRIPTION
### What does it do? Why?

This is required because when squashing a PR with only one commit, the commit message is used instead of the title of the PR.
