### PR TITLE
Fix GitHub Reverts

### DIFF
--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -75,7 +75,7 @@ exports.validatePR = async function validatePR({ pullRequest }) {
     );
   }
 
-  if (commits === 1) {
+  if (commits === 1 && !title.match(/^Revert ".*"/)) {
     // we have only one commit, make sure its name match the name of the PR
     const {
       data: { message: commitMessage },


### PR DESCRIPTION
### What does it do? Why?

They were broken since we enforced commit messages to be the same than PR title
