### PR TITLE
Add support for ms-bot single commit PRs

### DIFF
--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -15,6 +15,7 @@ exports.validatePR = async function validatePR({ pullRequest }) {
         owner: { login: owner },
         name: repo,
       },
+      user: { login: committer },
     },
     head: { ref: headRef, sha: headSha },
     title,
@@ -78,7 +79,8 @@ exports.validatePR = async function validatePR({ pullRequest }) {
   if (
     commits === 1 &&
     !title.match(/^Revert ".*"/) &&
-    !title.match(/^Bump .*/)
+    !title.match(/^Bump .*/) &&
+    !committer === "ms-bot"
   ) {
     // we have only one commit, make sure its name match the name of the PR
     const {


### PR DESCRIPTION
### What does it do? Why?

Allow ms-bot to create PR with a single commit and a commit message that doesn't match PR title

Use : https://api.github.com/users/ms-bot to check the ms-bot login name.
And use https://gist.github.com/colbyfayock/1710edb9f47ceda0569844f791403e7e as reference
