### PR TITLE
Add support for at sign to regex branche

### DIFF
--- a/lib/branch.js
+++ b/lib/branch.js
@@ -2,6 +2,7 @@ exports.isBranchNameValid = (branchName) =>
   (!!branchName.match(
     /^(core|feature|fix|hotfix|asset|rework|documentation|mobsuccessbot|dependabot)\/([a-z][a-z0-9.-]*)$/
   ) ||
+    !!branchName.match(/^(mobsuccessbot)\/([a-z][a-z0-9_\-@.\/_-]*)$ ||
     !!branchName.match(/^(dependabot)\/([a-z][a-z0-9./_-]*)$/) ||
     !!branchName.match(/^revert-[0-9]+-/) ||
     !!branchName.match(/^(rework)\/([A-Z][a-zA-Z0-9.-]*)$/)) &&

--- a/lib/branch.js
+++ b/lib/branch.js
@@ -2,7 +2,7 @@ exports.isBranchNameValid = (branchName) =>
   (!!branchName.match(
     /^(core|feature|fix|hotfix|asset|rework|documentation|mobsuccessbot|dependabot)\/([a-z][a-z0-9.-]*)$/
   ) ||
-    !!branchName.match(/^(mobsuccessbot)\/([a-z][a-z0-9_\-@./_-]*)$/) ||
+    !!branchName.match(/^(mobsuccessbot)\/([a-z0-9_\-@./_-]*)$/) ||
     !!branchName.match(/^(dependabot)\/([a-z][a-z0-9./_-]*)$/) ||
     !!branchName.match(/^revert-[0-9]+-/) ||
     !!branchName.match(/^(rework)\/([A-Z][a-zA-Z0-9.-]*)$/)) &&

--- a/lib/branch.js
+++ b/lib/branch.js
@@ -2,7 +2,7 @@ exports.isBranchNameValid = (branchName) =>
   (!!branchName.match(
     /^(core|feature|fix|hotfix|asset|rework|documentation|mobsuccessbot|dependabot)\/([a-z][a-z0-9.-]*)$/
   ) ||
-    !!branchName.match(/^(mobsuccessbot)\/([a-z][a-z0-9_\-@.\/_-]*)$ ||
+    !!branchName.match(/^(mobsuccessbot)\/([a-z][a-z0-9_\-@./_-]*)$/) ||
     !!branchName.match(/^(dependabot)\/([a-z][a-z0-9./_-]*)$/) ||
     !!branchName.match(/^revert-[0-9]+-/) ||
     !!branchName.match(/^(rework)\/([A-Z][a-zA-Z0-9.-]*)$/)) &&

--- a/lib/branch.test.js
+++ b/lib/branch.test.js
@@ -15,6 +15,7 @@ describe("branch", () => {
       true
     );
     expect(isBranchNameValid("mobsuccessbot/foo")).toBe(true);
+    expect(isBranchNameValid("mobsuccessbot/foo@foo")).toBe(true);
     expect(isBranchNameValid("mobsuccessbot/foo@foo/foo")).toBe(true);
     expect(isBranchNameValid("foo/foo-bar")).toBe(false);
     expect(isBranchNameValid("core/foo--bar")).toBe(true);

--- a/lib/branch.test.js
+++ b/lib/branch.test.js
@@ -15,6 +15,7 @@ describe("branch", () => {
       true
     );
     expect(isBranchNameValid("mobsuccessbot/foo")).toBe(true);
+    expect(isBranchNameValid("mobsuccessbot/foo@foo/foo")).toBe(true);
     expect(isBranchNameValid("foo/foo-bar")).toBe(false);
     expect(isBranchNameValid("core/foo--bar")).toBe(true);
     expect(isBranchNameValid("core/foo--bar--z")).toBe(true);


### PR DESCRIPTION
### What does it do? Why?
Add support to `at sign` to allow this kind of branche :
`mobsuccessbot/updater-bump-@mobsuccess-devops/streamline`
### QA
`npm run test`
### Good To Know
