### PR TITLE
Fix dependabot branch name rules

### DIFF
--- a/lib/branch.js
+++ b/lib/branch.js
@@ -3,7 +3,7 @@ exports.isBranchNameValid = (branchName) =>
     /^(core|feature|fix|hotfix|asset|rework|documentation|mobsuccessbot|dependabot)\/([a-z][a-z0-9.-]*)$/
   ) ||
     !!branchName.match(/^(mobsuccessbot)\/([a-z0-9_\-@./_-]*)$/) ||
-    !!branchName.match(/^(dependabot)\/([a-z][a-z0-9./_-]*)$/) ||
+    !!branchName.match(/^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/) ||
     !!branchName.match(/^revert-[0-9]+-/) ||
     !!branchName.match(/^(rework)\/([A-Z][a-zA-Z0-9.-]*)$/)) &&
   !branchName.match(/---/) &&


### PR DESCRIPTION
### What does it do? Why?

Nous pouvons avoir des majuscules dans le nom de la branche créée par dependabot :
https://mobsuccess.slack.com/archives/G01QAN1JR4L/p1664309236071459?thread_ts=1664266775.946129&cid=G01QAN1JR4L