### PR TITLE
Add merge --onto comment on subbranches

### DIFF
--- a/action.js
+++ b/action.js
@@ -20,6 +20,7 @@ exports.action = async function action() {
       break;
     case "after-pr-merged":
       await onPRMerged({ pullRequest });
+      break;
     case "changelog":
       await generateChangelog({ pullRequest });
       break;

--- a/action.js
+++ b/action.js
@@ -2,6 +2,7 @@ const core = require("@actions/core");
 const github = require("@actions/github");
 //const getOctokit = require("./lib/actions/octokit");
 const { validatePR } = require("./lib/actions/pullRequest");
+const { onPRMerged } = require("./lib/actions/pullRequestMerged");
 
 exports.getActionParameters = function getActionParameters() {
   const pullRequest = github.context.payload.pull_request;
@@ -16,6 +17,9 @@ exports.action = async function action() {
   switch (action) {
     case "validate-pr":
       await validatePR({ pullRequest });
+      break;
+    case "after-pr-merged":
+      await onPRMerged({ pullRequest });
       break;
   }
 };

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: "Github Actions Mobsuccess"
 description: "Github Mobsuccess Compliance"
 inputs:
   action:
-    description: "The action to be performed: validate-pr"
+    description: "The action to be performed: validate-pr or after-pr-merged"
     required: false
   github-token:
     description: "your github auth token"

--- a/lib/actions/pullRequestMerged.js
+++ b/lib/actions/pullRequestMerged.js
@@ -100,7 +100,7 @@ git push -f
 exports.onPRMerged = async function onPRMerged({ pullRequest }) {
   console.log("Performing onPRMerged");
   const { base, head } = pullRequest;
-  if (base.ref !== "master" || !head.ref.includes("--")) {
+  if (base.ref !== "master") {
     return;
   }
   await sendRebaseOntoCommentOnSubbranches({

--- a/lib/actions/pullRequestMerged.js
+++ b/lib/actions/pullRequestMerged.js
@@ -37,17 +37,8 @@ const sendRebaseOntoCommentOnSubbranches = async ({
 💡 Base PR #${mergedPrNumber} has been squashed merged into master.
 
 👉 This PR should be rebased on master using:
-- Fetch all:
 \`\`\`bash
-git fetch
-\`\`\`
-- Rebase on master using last common commit:
-\`\`\`bash
-git rebase --onto origin/master ${lastCommitOfParentPR}
-\`\`\` 
-- Force push to your branch:
-\`\`\`bash
-git push -f
+git fetch && git rebase --onto origin/master ${lastCommitOfParentPR} && git push -f
 \`\`\` 
 `;
 

--- a/lib/actions/pullRequestMerged.js
+++ b/lib/actions/pullRequestMerged.js
@@ -1,0 +1,113 @@
+const { getOctokit } = require("./octokit");
+
+const octokit = getOctokit();
+
+const sendRebaseOntoCommentOnSubbranches = async ({
+  repo: repoObject,
+  mergedPrNumber,
+}) => {
+  const {
+    owner: { login: owner },
+    name: repo,
+  } = repoObject;
+  // fetch the pull request from github
+  const { data: pr } = await octokit.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: mergedPrNumber,
+  });
+  if (pr.base.ref !== "master" || !pr.merge_commit_sha) {
+    return;
+  }
+  // get all open branches from the repository
+  const { data: branches } = await octokit.rest.repos.listBranches({
+    owner,
+    repo,
+  });
+  // filter out branches that are not subbranches of the merged PR
+  const subbranches = branches.filter((branch) => {
+    return branch.name.startsWith(`${pr.head.ref}--`);
+  });
+
+  const lastCommitOfParentPR = pr.head.sha;
+  const commentToDetectComment =
+    "<!-- comment by ms-bot to inform of base branch merged -->";
+
+  const body = `${commentToDetectComment}
+💡 Base PR #${mergedPrNumber} has been squashed merged into master.
+
+👉 This PR should be rebased on master using:
+- Fetch all:
+\`\`\`bash
+git fetch
+\`\`\`
+- Rebase on master using last common commit:
+\`\`\`bash
+git rebase --onto origin/master ${lastCommitOfParentPR}
+\`\`\` 
+- Force push to your branch:
+\`\`\`bash
+git push -f
+\`\`\` 
+`;
+
+  // post a comment in each subbranches PRs
+  for (const branch of subbranches) {
+    const { data: branchPr } = await octokit.rest.pulls.list({
+      owner,
+      repo,
+      head: `${owner}:${branch.name}`,
+    });
+    if (
+      branchPr.length === 0 ||
+      branchPr[0].closed_at ||
+      branchPr[0].merged_at
+    ) {
+      continue;
+    }
+    console.log(
+      `*** PR #${branchPr[0].number} is a subpr of #${mergedPrNumber} which has been merged into master`
+    );
+    const { data: comments } = await octokit.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number: branchPr[0].number,
+    });
+    const comment = comments.find((comment) => {
+      return comment.body.startsWith(commentToDetectComment);
+    });
+    if (comment) {
+      // if body is different, update body
+      if (comment.body !== body) {
+        await octokit.rest.issues.updateComment({
+          owner,
+          repo,
+          comment_id: comment.id,
+          body,
+        });
+      }
+      continue;
+    }
+    await octokit.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: branchPr[0].number,
+      body,
+    });
+  }
+};
+
+exports.onPRMerged = async function onPRMerged({ pullRequest }) {
+  console.log("Performing onPRMerged");
+  const { base, head } = pullRequest;
+  if (base.ref !== "master" || !head.ref.includes("--")) {
+    return;
+  }
+  await sendRebaseOntoCommentOnSubbranches({
+    repo: {
+      owner: { login: head.repo.owner.login },
+      name: head.repo.name,
+    },
+    mergedPrNumber: pullRequest.number,
+  });
+};

--- a/sample/workflows/closed.yml
+++ b/sample/workflows/closed.yml
@@ -22,3 +22,14 @@ jobs:
     steps:
       - name: "Sync emoji in #mobsuccess-review-requested"
         run: 'curl -D /dev/stderr -s "${{ secrets.ZAPIER_REVIEW_REQUESTED_RED_CROSS }}?repo=${{ github.repository }}&pr=${{ github.event.number }}"'
+
+  CommentSubPRs:
+    if: github.event.pull_request.merged == true
+    name: "Comment rebase --onto on Sub PRs"
+    runs-on: ubuntu-20.04
+    timeout-minutes: 2
+    steps:
+      - uses: mobsuccess-devops/github-actions-mobsuccess@master
+        with:
+          github-token: ${{ github.token }}
+          action: "after-pr-merged"


### PR DESCRIPTION
### What does it do? Why?

👉🏻 &nbsp;Please add a description of what this `pull request` does.
Regarding subPRs (branches containing `--`) : 
- when the main branch is squashed merged, it can become difficult to know on which commit we should rebase
- this PRs creates (and updates if needed) a comment on each sub PR (= PR having a base branch merged on master)

The result looks like: https://github.com/mobsuccess-devops/package-debug/pull/23#issuecomment-1300526761 

Source discussion on slack: https://mobsuccess.slack.com/archives/C031L5J9F96/p1667222029482189

### Good To Know

👉🏻 &nbsp;Link to the asana ticket. Dont start a `pull request` without a ticket.

### QA

👉🏻 &nbsp;Please add what you think the reviewer has to test (remove this line and replace with your comment)

### Review

- [ ] All GHA are success - except Asana
- [ ] There is no new harcoded text, all has to be set with lingui
- [ ] Use react-ui when possible
- [ ] Costly calculations use `useMemo`
- [ ] The PR does not add svg, png, jpg but use streamline instead
- [ ] The PR does not add `eslint-disable` directives
- [ ] The Asana Changelog field has been set
