### PR TITLE
Add action to generate changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,22 @@ pull request, the names of the branch…
 
 You do not need to make any action to install the GitHub Action workflow,
 ms-bot will automatically make PRs on your repository when changes are needed.
+
+# ACTIONS
+
+## Changelog
+
+The changelog action allows to generate on a particular repo, a changelog for the last X tags.
+
+The "latest tag" corresponds to a tag that has not been pushed as a release. As this action is based on GH releases, it allows to generate the changelog between the last release and the tag being created right now.
+
+Usage:
+
+```yml
+- uses: mobsuccess-devops/github-actions-mobsuccess@master
+  with:
+    github-token: ${{ github.token }}
+    action: changelog
+    max-releases: 10 #(optional, default to 10)
+    unreleased-tag: 0.0.90289303809 # newly created unreleased tag (optional)
+```

--- a/action.js
+++ b/action.js
@@ -1,6 +1,5 @@
 const core = require("@actions/core");
 const github = require("@actions/github");
-//const getOctokit = require("./lib/actions/octokit");
 const { validatePR } = require("./lib/actions/pullRequest");
 const { generateChangelog } = require("./lib/actions/changelog");
 

--- a/action.js
+++ b/action.js
@@ -2,6 +2,7 @@ const core = require("@actions/core");
 const github = require("@actions/github");
 //const getOctokit = require("./lib/actions/octokit");
 const { validatePR } = require("./lib/actions/pullRequest");
+const { generateChangelog } = require("./lib/actions/changelog");
 
 exports.getActionParameters = function getActionParameters() {
   const pullRequest = github.context.payload.pull_request;
@@ -16,6 +17,9 @@ exports.action = async function action() {
   switch (action) {
     case "validate-pr":
       await validatePR({ pullRequest });
+      break;
+    case "changelog":
+      await generateChangelog({ pullRequest });
       break;
   }
 };

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: "Github Actions Mobsuccess"
 description: "Github Mobsuccess Compliance"
 inputs:
   action:
-    description: "The action to be performed: validate-pr"
+    description: "The action to be performed: validate-pr or changelog"
     required: false
   github-token:
     description: "your github auth token"
@@ -13,6 +13,15 @@ inputs:
   storybook-amplify-uri:
     description: "the AWS Amplify Storybook URI template"
     required: false
+  unreleased-tag:
+    description: "Latest unreleased (yet) tag for which to generate changelog"
+    required: false
+  max-releases:
+    description: "The number of releases for which to generate a changelog"
+    required: false
+outputs:
+  changelog:
+    description: "The generated changelog"
 branding:
   icon: "chevron-right"
   color: "gray-dark"

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -64,7 +64,7 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
   const changelog = await Promise.all(
     reversedReleases.map(async (release, index, arr) => {
       let nextRelease = index + 1 < arr.length ? arr[index + 1] : null;
-      const tag = nextRelease?.tag_name ?? latestTagInput;
+      const tag = nextRelease ? nextRelease.tag_name : latestTagInput;
       if (tag) {
         console.log(
           `Generating changelog for ${tag}, previous release= ${release.tag_name}`
@@ -96,13 +96,11 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
 
   const changelogContentArray = changelog.map(
     ({ release, tag, previousRelease, pullRequests = [] }) => {
-      const currentTag = release?.tag_name ?? tag;
+      const currentTag = release ? release.tag_name : tag;
       if (!currentTag) {
         return "";
       }
-      const date = release?.published_at
-        ? new Date(release.published_at)
-        : new Date();
+      const date = release ? new Date(release.published_at) : new Date();
       const niceDate =
         date.toLocaleDateString() + " - " + date.toLocaleTimeString();
       const results = [`## ${currentTag} (${niceDate})`];

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -30,9 +30,9 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
 
   let maxReleases = core.getInput("max-releases");
   if (maxReleases) {
-    maxReleases = parseInt(maxReleases, 10);
+    maxReleases = parseInt(maxReleases, 10) + 1;
   } else {
-    maxReleases = 10;
+    maxReleases = 11;
   }
 
   const releases = await getLatestsReleases({

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -110,7 +110,7 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
         results.push(
           pullRequests
             .map((pr) => {
-              return `- \`${pr.title}\` #${pr.number} by @${pr.user.login}`;
+              return `- [${pr.title}](https://github.com/${repo.owner.login}/pull/${pr.number}) #${pr.number} by @${pr.user.login}`;
             })
             .join("\n")
         );

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -62,19 +62,19 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
 
   // generate changelog for each release
   const changelog = await Promise.all(
-    reversedReleases.map(async (release, index, arr) => {
-      let nextRelease = index + 1 < arr.length ? arr[index + 1] : null;
-      const tag = nextRelease ? nextRelease.tag_name : latestTagInput;
+    reversedReleases.map(async (previousRelease, index, arr) => {
+      let release = index + 1 < arr.length ? arr[index + 1] : null;
+      const tag = release ? release.tag_name : latestTagInput;
       if (tag) {
         console.log(
-          `Generating changelog for ${tag}, previous release= ${release.tag_name}`
+          `Generating changelog for ${tag}, previous release= ${previousRelease.tag_name}`
         );
         // list pull request in between those tags
         const commitsBetweenThoseTwoTags = await octokit.rest.repos.compareCommits(
           {
             owner: repo.owner.login,
             repo: repo.name,
-            base: release.tag_name,
+            base: previousRelease.tag_name,
             head: tag,
           }
         );
@@ -84,8 +84,8 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
           commitsHashes.includes(pr.merge_commit_sha)
         );
         return {
-          release: nextRelease,
-          previousRelease: release,
+          release,
+          previousRelease,
           tag,
           pullRequests,
         };

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -1,0 +1,134 @@
+const core = require("@actions/core");
+const { getOctokit } = require("./octokit");
+const semverGt = require("semver/functions/gt");
+
+const octokit = getOctokit();
+
+// return latest releases sorted by creation date desc
+const getLatestsReleases = async ({ owner, repo, maxCount = 10 }) => {
+  const { data: releases } = await octokit.rest.repos.listReleases({
+    owner,
+    repo,
+    per_page: 100,
+  });
+  return releases
+    .filter((release) => !!release.tag_name)
+    .sort((a, b) => semverGt(a.tag_name, b.tag_name))
+    .slice(0, maxCount);
+};
+
+exports.generateChangelog = async function generateChangelog({ pullRequest }) {
+  console.log("Generating changelog");
+
+  const latestTagInput = core.getInput("unreleased-tag");
+
+  const { base, head } = pullRequest;
+  const repo = {
+    owner: { login: head.repo.owner.login },
+    name: head.repo.name,
+  };
+
+  let maxReleases = core.getInput("max-releases");
+  if (maxReleases) {
+    maxReleases = parseInt(maxReleases, 10);
+  } else {
+    maxReleases = 10;
+  }
+
+  const releases = await getLatestsReleases({
+    owner: pullRequest.base.repo.owner.login,
+    repo: pullRequest.base.repo.name,
+    maxCount: maxReleases,
+  });
+
+  // list last 100 pull requests
+  const { data: pullRequests } = await octokit.rest.pulls.list({
+    owner: repo.owner.login,
+    repo: repo.name,
+    base: base.ref,
+    state: "closed",
+    sort: "updated",
+    direction: "desc",
+    per_page: 100,
+  });
+
+  // filter pull requests that are not merged
+  const mergedPullRequests = pullRequests
+    .filter((pr) => !!pr.merge_commit_sha)
+    .filter((pr) => pr.base.ref === base.ref);
+
+  // reverse releases to have the oldest first
+  const reversedReleases = releases.reverse();
+
+  // generate changelog for each release
+  const changelog = await Promise.all(
+    reversedReleases.map(async (release, index, arr) => {
+      let nextRelease = index + 1 < arr.length ? arr[index + 1] : null;
+      const tag = nextRelease?.tag_name ?? latestTagInput;
+      if (tag) {
+        console.log(
+          `Generating changelog for ${tag}, previous release= ${release.tag_name}`
+        );
+        // list pull request in between those tags
+        const commitsBetweenThoseTwoTags = await octokit.rest.repos.compareCommits(
+          {
+            owner: repo.owner.login,
+            repo: repo.name,
+            base: release.tag_name,
+            head: tag,
+          }
+        );
+        const commits = commitsBetweenThoseTwoTags.data.commits;
+        const commitsHashes = commits.map((commit) => commit.sha);
+        const pullRequests = mergedPullRequests.filter((pr) =>
+          commitsHashes.includes(pr.merge_commit_sha)
+        );
+        return {
+          release: nextRelease,
+          previousRelease: release,
+          tag,
+          pullRequests,
+        };
+      }
+      return {};
+    })
+  );
+
+  const changelogContentArray = changelog.map(
+    ({ release, tag, previousRelease, pullRequests = [] }) => {
+      const currentTag = release?.tag_name ?? tag;
+      if (!currentTag) {
+        return "";
+      }
+      const date = release?.published_at
+        ? new Date(release.published_at)
+        : new Date();
+      const niceDate =
+        date.toLocaleDateString() + " - " + date.toLocaleTimeString();
+      const results = [`## ${currentTag} (${niceDate})`];
+
+      if (pullRequests.length) {
+        results.push("");
+        results.push(
+          pullRequests
+            .map((pr) => {
+              return `- \`${pr.title}\` #${pr.number} by @${pr.user.login}`;
+            })
+            .join("\n")
+        );
+      }
+
+      if (previousRelease) {
+        results.push("");
+        results.push(
+          `**Full Changelog**: https://github.com/${repo.owner.login}/${repo.name}/compare/${previousRelease.tag_name}...${currentTag}`
+        );
+      }
+      return results.join("\n");
+    }
+  );
+
+  const changelogContent = changelogContentArray.reverse().join("\n\n");
+
+  core.setOutput("changelog", changelogContent.trim());
+};

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -20,7 +20,7 @@ const getLatestsReleases = async ({ owner, repo, maxCount = 10 }) => {
 exports.generateChangelog = async function generateChangelog({ pullRequest }) {
   console.log("Generating changelog");
 
-  const latestTagInput = core.getInput("unreleased-tag");
+  const latestTagInput = core.getInput("unreleased-tag") || null; // default to null, in case the action passes false or an empty string
 
   const { base, head } = pullRequest;
   const repo = {


### PR DESCRIPTION
### What does it do? Why?

👉🏻 &nbsp;Please add a description of what this `pull request` does.

This allows us to generate a changelog for repos based on our merged PRs and tag versioning

The action has been tested on "package-debug" : https://github.com/mobsuccess-devops/package-debug/actions/runs/3594487634/jobs/6052869237

### Good To Know

The changelog looks like this : 

## 0.0.3594487635-pr-28.0 (12/1/2022 - 4:27:20 PM)

**Full Changelog**: https://github.com/mobsuccess-devops/package-debug/compare/0.0.3593040284...0.0.3594487635-pr-28.0

## 0.0.3593040284 (12/1/2022 - 1:32:10 PM)

-  #27 by @ms-bot

**Full Changelog**: https://github.com/mobsuccess-devops/package-debug/compare/0.0.3593034806...0.0.3593040284

