### PR TITLE
Remove GH username notification

### DIFF
--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -112,7 +112,9 @@ exports.generateChangelog = async function generateChangelog({
             .map((pr) => {
               return `- [${pr.title.replace(/"/g, "")}](https://github.com/${
                 repository.owner.login
-              }/${repository.name}/pull/${pr.number}) #${pr.number} by [${pr.user.login}](https://github.com/${pr.user.login})`;
+              }/${repository.name}/pull/${pr.number}) #${pr.number} by [${
+                pr.user.login
+              }](https://github.com/${pr.user.login})`;
             })
             .join("\n")
         );

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -110,7 +110,7 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
         results.push(
           pullRequests
             .map((pr) => {
-              return `- [${pr.title}](https://github.com/${repo.owner.login}/pull/${pr.number}) #${pr.number} by @${pr.user.login}`;
+              return `- [${pr.title}](https://github.com/${repo.owner.login}/pull/${pr.number}) #${pr.number} by [${pr.user.login}](https://github.com/${pr.user.login})`;
             })
             .join("\n")
         );


### PR DESCRIPTION
### What does it do? Why?

👉🏻 &nbsp;Please add a description of what this `pull request` does.

This PRs replace all usernames in changelogs by a simple link to their profile.
=> We still have a link to their user profile if needed, but they don't get a notification.

### Good To Know

👉🏻 &nbsp;Link to the asana ticket. Dont start a `pull request` without a ticket.

### QA

👉🏻 &nbsp;Please add what you think the reviewer has to test (remove this line and replace with your comment)

### Review

- [ ] All GHA are success - except Asana
- [ ] There is no new harcoded text, all has to be set with lingui
- [ ] Use react-ui when possible
- [ ] Costly calculations use `useMemo`
- [ ] The PR does not add svg, png, jpg but use streamline instead
- [ ] The PR does not add `eslint-disable` directives
- [ ] The Asana Changelog field has been set
