### PR TITLE
Fix new changelog for master

### DIFF
--- a/action.js
+++ b/action.js
@@ -5,7 +5,7 @@ const { onPRMerged } = require("./lib/actions/pullRequestMerged");
 const { generateChangelog } = require("./lib/actions/changelog");
 
 exports.getActionParameters = function getActionParameters() {
-  const repository = github.context.repository;
+  const repository = github.context.payload.repository;
   const ref = github.context.ref;
   const pullRequest = github.context.payload.pull_request;
   const action = core.getInput("action", { required: true });
@@ -21,10 +21,6 @@ exports.action = async function action() {
   } = exports.getActionParameters();
 
   console.info(`Calling action ${action}`);
-  console.info(
-    `With context ${JSON.stringify(github.context)}`,
-    github.context
-  );
   switch (action) {
     case "validate-pr":
       await validatePR({ pullRequest });

--- a/action.js
+++ b/action.js
@@ -21,7 +21,10 @@ exports.action = async function action() {
   } = exports.getActionParameters();
 
   console.info(`Calling action ${action}`);
-  console.info(`With context ${github.context}`);
+  console.info(
+    `With context ${JSON.stringify(github.context)}`,
+    github.context
+  );
   switch (action) {
     case "validate-pr":
       await validatePR({ pullRequest });

--- a/action.js
+++ b/action.js
@@ -21,7 +21,6 @@ exports.action = async function action() {
   } = exports.getActionParameters();
 
   console.info(`Calling action ${action}`);
-  console.info(`With context`, github.context);
   switch (action) {
     case "validate-pr":
       await validatePR({ pullRequest });

--- a/action.js
+++ b/action.js
@@ -5,13 +5,20 @@ const { onPRMerged } = require("./lib/actions/pullRequestMerged");
 const { generateChangelog } = require("./lib/actions/changelog");
 
 exports.getActionParameters = function getActionParameters() {
+  const repository = github.context.repository;
+  const ref = github.context.ref;
   const pullRequest = github.context.payload.pull_request;
   const action = core.getInput("action", { required: true });
-  return { pullRequest, action };
+  return { repository, ref, pullRequest, action };
 };
 
 exports.action = async function action() {
-  const { pullRequest, action } = exports.getActionParameters();
+  const {
+    repository,
+    ref,
+    pullRequest,
+    action,
+  } = exports.getActionParameters();
 
   console.info(`Calling action ${action}`);
   switch (action) {
@@ -22,7 +29,7 @@ exports.action = async function action() {
       await onPRMerged({ pullRequest });
       break;
     case "changelog":
-      await generateChangelog({ pullRequest });
+      await generateChangelog({ repository, pullRequest, ref });
       break;
   }
 };

--- a/action.js
+++ b/action.js
@@ -21,6 +21,7 @@ exports.action = async function action() {
   } = exports.getActionParameters();
 
   console.info(`Calling action ${action}`);
+  console.info(`With context ${github.context}`);
   switch (action) {
     case "validate-pr":
       await validatePR({ pullRequest });

--- a/action.js
+++ b/action.js
@@ -21,6 +21,7 @@ exports.action = async function action() {
   } = exports.getActionParameters();
 
   console.info(`Calling action ${action}`);
+  console.info(`With context`, github.context);
   switch (action) {
     case "validate-pr":
       await validatePR({ pullRequest });

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -57,6 +57,15 @@ exports.generateChangelog = async function generateChangelog({
     .filter((pr) => !!pr.merge_commit_sha)
     .filter((pr) => pr.base.ref === ref);
 
+  console.log("some debug stats", {
+    latestTagInput,
+    ref,
+    maxReleases,
+    releasesCount: releases.length,
+    pullRequestsCount: pullRequests.length,
+    mergedPullRequestsCount: mergedPullRequests.length,
+  });
+
   // reverse releases to have the oldest first
   const reversedReleases = releases.reverse();
 

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -110,7 +110,7 @@ exports.generateChangelog = async function generateChangelog({
         results.push(
           pullRequests
             .map((pr) => {
-              return `- [${pr.title}](https://github.com/${repoitory.owner.login}/pull/${pr.number}) #${pr.number} by @${pr.user.login}`;
+              return `- [${pr.title}](https://github.com/${repository.owner.login}/pull/${pr.number}) #${pr.number} by @${pr.user.login}`;
             })
             .join("\n")
         );

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -57,15 +57,6 @@ exports.generateChangelog = async function generateChangelog({
     .filter((pr) => !!pr.merge_commit_sha)
     .filter((pr) => pr.base.ref === ref.replace("refs/heads/", ""));
 
-  console.log("some debug stats", {
-    latestTagInput,
-    ref,
-    maxReleases,
-    releasesCount: releases.length,
-    pullRequestsCount: pullRequests.length,
-    mergedPullRequestsCount: mergedPullRequests.length,
-  });
-
   // reverse releases to have the oldest first
   const reversedReleases = releases.reverse();
 

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -55,10 +55,7 @@ exports.generateChangelog = async function generateChangelog({
   // filter pull requests that are not merged
   const mergedPullRequests = pullRequests
     .filter((pr) => !!pr.merge_commit_sha)
-    .filter((pr) => {
-      console.log("testing", pr.base.ref);
-      return pr.base.ref === ref;
-    });
+    .filter((pr) => pr.base.ref === ref.replace("refs/heads/", ""));
 
   console.log("some debug stats", {
     latestTagInput,

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -17,16 +17,16 @@ const getLatestsReleases = async ({ owner, repo, maxCount = 10 }) => {
     .slice(0, maxCount);
 };
 
-exports.generateChangelog = async function generateChangelog({ pullRequest }) {
+exports.generateChangelog = async function generateChangelog({
+  repository,
+  pullRequest,
+  ref: refFromContext,
+}) {
   console.log("Generating changelog");
 
   const latestTagInput = core.getInput("unreleased-tag") || null; // default to null, in case the action passes false or an empty string
 
-  const { base, head } = pullRequest;
-  const repo = {
-    owner: { login: head.repo.owner.login },
-    name: head.repo.name,
-  };
+  const ref = pullRequest ? pullRequest.base.ref : refFromContext;
 
   let maxReleases = core.getInput("max-releases");
   if (maxReleases) {
@@ -36,16 +36,16 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
   }
 
   const releases = await getLatestsReleases({
-    owner: pullRequest.base.repo.owner.login,
-    repo: pullRequest.base.repo.name,
+    owner: repository.owner.login,
+    repo: repository.name,
     maxCount: maxReleases,
   });
 
   // list last 100 pull requests
   const { data: pullRequests } = await octokit.rest.pulls.list({
-    owner: repo.owner.login,
-    repo: repo.name,
-    base: base.ref,
+    owner: repository.owner.login,
+    repo: repository.name,
+    base: ref,
     state: "closed",
     sort: "updated",
     direction: "desc",
@@ -55,7 +55,7 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
   // filter pull requests that are not merged
   const mergedPullRequests = pullRequests
     .filter((pr) => !!pr.merge_commit_sha)
-    .filter((pr) => pr.base.ref === base.ref);
+    .filter((pr) => pr.base.ref === ref);
 
   // reverse releases to have the oldest first
   const reversedReleases = releases.reverse();
@@ -72,8 +72,8 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
         // list pull request in between those tags
         const commitsBetweenThoseTwoTags = await octokit.rest.repos.compareCommits(
           {
-            owner: repo.owner.login,
-            repo: repo.name,
+            owner: repository.owner.login,
+            repo: repository.name,
             base: previousRelease.tag_name,
             head: tag,
           }
@@ -110,7 +110,7 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
         results.push(
           pullRequests
             .map((pr) => {
-              return `- [${pr.title}](https://github.com/${repo.owner.login}/pull/${pr.number}) #${pr.number} by @${pr.user.login}`;
+              return `- [${pr.title}](https://github.com/${repoitory.owner.login}/pull/${pr.number}) #${pr.number} by @${pr.user.login}`;
             })
             .join("\n")
         );
@@ -119,7 +119,7 @@ exports.generateChangelog = async function generateChangelog({ pullRequest }) {
       if (previousRelease) {
         results.push("");
         results.push(
-          `**Full Changelog**: https://github.com/${repo.owner.login}/${repo.name}/compare/${previousRelease.tag_name}...${currentTag}`
+          `**Full Changelog**: https://github.com/${repository.owner.login}/${repository.name}/compare/${previousRelease.tag_name}...${currentTag}`
         );
       }
       return results.join("\n");

--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -55,7 +55,10 @@ exports.generateChangelog = async function generateChangelog({
   // filter pull requests that are not merged
   const mergedPullRequests = pullRequests
     .filter((pr) => !!pr.merge_commit_sha)
-    .filter((pr) => pr.base.ref === ref);
+    .filter((pr) => {
+      console.log("testing", pr.base.ref);
+      return pr.base.ref === ref;
+    });
 
   console.log("some debug stats", {
     latestTagInput,


### PR DESCRIPTION
### What does it do? Why?

👉🏻 &nbsp;Please add a description of what this `pull request` does.
The new changelog was working only on PR runs. It now also work without a pull request, when running on master for example.

Testé sur https://github.com/mobsuccess-devops/package-debug/actions/runs/3628056504/jobs/6118965734

### Good To Know

👉🏻 &nbsp;Link to the asana ticket. Dont start a `pull request` without a ticket.

### QA

👉🏻 &nbsp;Please add what you think the reviewer has to test (remove this line and replace with your comment)

### Review

- [ ] All GHA are success - except Asana
- [ ] There is no new harcoded text, all has to be set with lingui
- [ ] Use react-ui when possible
- [ ] Costly calculations use `useMemo`
- [ ] The PR does not add svg, png, jpg but use streamline instead
- [ ] The PR does not add `eslint-disable` directives
- [ ] The Asana Changelog field has been set
