### PR TITLE
Fix " breaking changelogs echo

### DIFF
--- a/lib/actions/changelog.js
+++ b/lib/actions/changelog.js
@@ -110,7 +110,11 @@ exports.generateChangelog = async function generateChangelog({
         results.push(
           pullRequests
             .map((pr) => {
-              return `- [${pr.title}](https://github.com/${repository.owner.login}/pull/${pr.number}) #${pr.number} by @${pr.user.login}`;
+              return `- [${pr.title.replace(/"/g, "")}](https://github.com/${
+                repository.owner.login
+              }/${repository.name}/pull/${pr.number}) #${pr.number} by @${
+                pr.user.login
+              }`;
             })
             .join("\n")
         );


### PR DESCRIPTION
### What does it do? Why?

👉🏻 Having a double quote character in a PR title broke the changelog generation

### Good To Know

👉🏻 &nbsp;Link to the asana ticket. Dont start a `pull request` without a ticket.

### QA

👉🏻 &nbsp;Please add what you think the reviewer has to test (remove this line and replace with your comment)

### Review

- [ ] All GHA are success - except Asana
- [ ] There is no new harcoded text, all has to be set with lingui
- [ ] Use react-ui when possible
- [ ] Costly calculations use `useMemo`
- [ ] The PR does not add svg, png, jpg but use streamline instead
- [ ] The PR does not add `eslint-disable` directives
- [ ] The Asana Changelog field has been set
