### PR TITLE
Add new verbs support to a pull request title

### DIFF
--- a/lib/pullRequest.js
+++ b/lib/pullRequest.js
@@ -1,6 +1,6 @@
 exports.isPullRequestTitleValid = (pullRequestName) =>
   !!pullRequestName.match(
-    /^(Add|Clean|Fix|Improve|Remove|Update|Rework|Ignore|Bump) .+$/
+    /^(Add|Clean|Fix|Improve|Remove|Update|Rework|Ignore|Bump|Switch|Migrate) .+$/
     /* remember to edit the Notion when changing this value:
        https://www.notion.so/mobsuccess/Git-Guidelines-41996ef576cb4f29b7737772b74289c5
      */


### PR DESCRIPTION
### What does it do? Why?
Add new verbs support to a pull request title :
- `Switch`
- `Migrate`
