### PR TITLE
Add ms-upgrade-aws in ignored committer

### DIFF
--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -80,7 +80,8 @@ exports.validatePR = async function validatePR({ pullRequest }) {
     commits === 1 &&
     !title.match(/^Revert ".*"/) &&
     !title.match(/^Bump .*/) &&
-    !committer === "ms-bot"
+    !committer === "ms-bot" &&
+    !committer === "ms-upgrade-aws"
   ) {
     // we have only one commit, make sure its name match the name of the PR
     const {


### PR DESCRIPTION
### What does it do? Why?

This let PRs such as https://github.com/mobsuccess-devops/microservice-client/pull/87 to pass