### PR TITLE
Add support for multiple amplify URIs in monorepos

### DIFF
--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -11,10 +11,10 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
   const amplifyUri = amplifyUriRaw.replace(/%/g, pullRequest.number);
   if (amplifyUri.match(/^{/)) {
     const result = [];
-    const amplifyUriMap = JSON.parse(amplifyUri);
+    const amplifyUris = JSON.parse(amplifyUri);
     for (const label of labels) {
-      if (amplifyUriMap[label]) {
-        result.push(amplifyUriMap[label]);
+      if (amplifyUris[label]) {
+        result.push(amplifyUris[label]);
       }
     }
     return result;

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -11,9 +11,10 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
   const amplifyUri = amplifyUriRaw.replace(/%/g, pullRequest.number);
   if (amplifyUri.match(/^{/)) {
     const result = [];
+    const amplifyUriMap = JSON.parse(amplifyUri);
     for (const label of labels) {
-      if (amplifyUri[label]) {
-        result.push(amplifyUri[label]);
+      if (amplifyUriMap[label]) {
+        result.push(amplifyUriMap[label]);
       }
     }
     return result;

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -1,20 +1,25 @@
 const core = require("@actions/core");
 const github = require("@actions/github");
 
-exports.getAmplifyURI = async function getAmplifyURI() {
+exports.getAmplifyURIs = async function getAmplifyURI() {
   const pullRequest = github.context.payload.pull_request;
-  const amplifyUri = core.getInput("amplify-uri");
-  if (!amplifyUri) {
+  const labels = pullRequest.labels.map((label) => label.name);
+  const amplifyUriRaw = core.getInput("amplify-uri");
+  if (!amplifyUriRaw) {
     return;
   }
-  return amplifyUri.replace("%", pullRequest.number);
-};
-
-exports.getStorybookAmplifyUri = async function getStorybookAmplifyUri() {
-  const pullRequest = github.context.payload.pull_request;
-  const storybookAmplifyUri = core.getInput("storybook-amplify-uri");
-  if (!storybookAmplifyUri) {
-    return;
+  const amplifyUri = amplifyUriRaw.replace(/%/g, pullRequest.number);
+  if (amplifyUri.match(/^{/)) {
+    const result = [];
+    for (const label of labels) {
+      if (amplifyUri[label]) {
+        result.push(amplifyUri[label]);
+      }
+    }
+    return result;
+  } else if (!amplifyUri) {
+    return null;
+  } else {
+    return [amplifyUri];
   }
-  return storybookAmplifyUri.replace("%", pullRequest.number);
 };

--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -3,7 +3,7 @@ const { isBranchNameValid } = require("../branch");
 const {
   isPullRequestTitleValid: isPullRequestTitleValid,
 } = require("../pullRequest");
-const { getAmplifyURIs, getStorybookAmplifyUri } = require("./amplify");
+const { getAmplifyURIs } = require("./amplify");
 
 exports.validatePR = async function validatePR({ pullRequest }) {
   const {

--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -3,7 +3,7 @@ const { isBranchNameValid } = require("../branch");
 const {
   isPullRequestTitleValid: isPullRequestTitleValid,
 } = require("../pullRequest");
-const { getAmplifyURI, getStorybookAmplifyUri } = require("./amplify");
+const { getAmplifyURIs, getStorybookAmplifyUri } = require("./amplify");
 
 exports.validatePR = async function validatePR({ pullRequest }) {
   const {
@@ -119,34 +119,44 @@ exports.validatePR = async function validatePR({ pullRequest }) {
 
   // do we have an AWS Amplify URI? If so, make sure that at least one comment
   // exists with a link to it
-  const amplifyUri = await getAmplifyURI();
-  if (!amplifyUri) {
+  const amplifyUris = await getAmplifyURIs();
+  if (!amplifyUris) {
     console.log("No AWS Amplify URI for this repository");
   } else {
-    const storybookAmplifyUri = await getStorybookAmplifyUri();
-    console.log(`AWS Amplify URI: ${amplifyUri}`);
+    console.log("AWS Amplify URIs: ", amplifyUris);
     const comments = await octokit.paginate(
       "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
       { owner, repo, issue_number: pullNumber }
     );
 
     // add a comment with the PR
-    if (comments.some(({ body }) => body.match(amplifyUri))) {
-      console.log("A comment already exists with a link to AWS Amplify");
+    const body = "AWS Amplify live test URI:\n" + amplifyUris.join("\n");
+    const previousComments = comments.filter(({ body }) =>
+      body.match(/AWS Amplify live/)
+    );
+    if (previousComments.length > 0) {
+      console.log(
+        "A comment already exists with a link to AWS Amplify, editing it"
+      );
+      const firstComment = previousComments[0];
+      await octokit.request(
+        "PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}",
+        {
+          owner,
+          repo,
+          comment_id: firstComment.id,
+          body,
+        }
+      );
     } else {
-      console.log("Comment with link to Amplify URI missing");
-      console.log("Adding comment with AWS Amplify URI");
+      console.log("Comment with link to Amplify URI missing, creating it");
       await octokit.request(
         "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
         {
           owner,
           repo,
           issue_number: pullNumber,
-          body: `AWS Amplify live test URI: [${amplifyUri}](${amplifyUri})${
-            !storybookAmplifyUri
-              ? ""
-              : `\n\nAWS Amplify Storybook URI: [${storybookAmplifyUri}](${storybookAmplifyUri})`
-          }`,
+          body,
         }
       );
     }


### PR DESCRIPTION
### What does it do? Why?

- So that we can track `mobsuccess-front` and maybe others
- Deprecate storybook live preview URL that is no longer used
