### PR TITLE
Add Display all monorepo amplify urls

### DIFF
--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -5,9 +5,7 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
   const pullRequest = github.context.payload.pull_request;
   const issue = github.context.payload.issue;
   const pullNumber = pullRequest?.number || issue?.number;
-  const labels =
-    pullRequest?.labels.map((label) => label.name) ||
-    issue?.labels.map((label) => label.name);
+
   const amplifyUriRaw = core.getInput("amplify-uri");
   if (!amplifyUriRaw) {
     console.log("No input for amplify-uri");
@@ -17,10 +15,8 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
   if (amplifyUri.match(/^{/)) {
     const result = [];
     const amplifyUris = JSON.parse(amplifyUri);
-    for (const label of labels) {
-      if (amplifyUris[label]) {
-        result.push(amplifyUris[label]);
-      }
+    for (const [key, url] of Object.entries(amplifyUris)) {
+      result.push(`- ${key}: ${url}`);
     }
     return result;
   } else if (!amplifyUri) {

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -5,6 +5,10 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
   const pullRequest = github.context.payload.pull_request;
   const issue = github.context.payload.issue;
   const pullNumber = pullRequest?.number || issue?.number;
+  const labels =
+    pullRequest?.labels.map((label) => label.name) ??
+    issue?.labels.map((label) => label.name) ??
+    [];
 
   const amplifyUriRaw = core.getInput("amplify-uri");
   if (!amplifyUriRaw) {
@@ -15,8 +19,15 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
   if (amplifyUri.match(/^{/)) {
     const result = [];
     const amplifyUris = JSON.parse(amplifyUri);
+    for (const label of labels) {
+      if (amplifyUris[label]) {
+        result.push(`- 🔥 ${label}: ${amplifyUris[label]}`);
+      }
+    }
     for (const [key, url] of Object.entries(amplifyUris)) {
-      result.push(`- ${key}: ${url}`);
+      if (!labels.includes(key)) {
+        result.push(`- 🪵 ${key}: ${url}`);
+      }
     }
     return result;
   } else if (!amplifyUri) {

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -20,7 +20,7 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
     const amplifyUris = JSON.parse(amplifyUri);
 
     const hasAtLeastOnePackageOrConfig = labels.some(
-      (label) => label.startsWith("package/") || label.startsWith("config/")
+      (label) => label.startsWith("packages/") || label.startsWith("configs/")
     );
 
     if (hasAtLeastOnePackageOrConfig) {

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -17,8 +17,6 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
   }
   const amplifyUri = amplifyUriRaw.replace(/%/g, pullNumber);
   if (amplifyUri.match(/^{/)) {
-    const links = [];
-    const hiddenLinks = [];
     const amplifyUris = JSON.parse(amplifyUri);
 
     const hasAtLeastOnePackageOrConfig = labels.some(
@@ -26,24 +24,26 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
     );
 
     if (hasAtLeastOnePackageOrConfig) {
-      for (const [url] of Object.values(amplifyUris)) {
-        links.push(url);
+      return {
+        links: Object.values(amplifyUris),
+      };
+    }
+
+    const links = [];
+    const hiddenLinks = [];
+    for (const label of labels) {
+      if (amplifyUris[label]) {
+        links.push(amplifyUris[label]);
       }
-    } else {
-      for (const label of labels) {
-        if (amplifyUris[label]) {
-          links.push(amplifyUris[label]);
-        }
-      }
-      for (const [key, url] of Object.entries(amplifyUris)) {
-        if (!labels.includes(key)) {
-          hiddenLinks.push(url);
-        }
+    }
+    for (const [key, url] of Object.entries(amplifyUris)) {
+      if (!labels.includes(key)) {
+        hiddenLinks.push(url);
       }
     }
     return { links, hiddenLinks };
   } else if (!amplifyUri) {
-    return null;
+    return {};
   } else {
     return { links: [amplifyUri] };
   }

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -21,12 +21,12 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
     const amplifyUris = JSON.parse(amplifyUri);
     for (const label of labels) {
       if (amplifyUris[label]) {
-        result.push(`- 🔥 ${label}: ${amplifyUris[label]}`);
+        result.push(`- 🔥 ${amplifyUris[label]}`);
       }
     }
     for (const [key, url] of Object.entries(amplifyUris)) {
       if (!labels.includes(key)) {
-        result.push(`- 🪵 ${key}: ${url}`);
+        result.push(`- 🪵 ${url}`);
       }
     }
     return result;

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -24,9 +24,7 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
     );
 
     if (hasAtLeastOnePackageOrConfig) {
-      return {
-        links: Object.values(amplifyUris),
-      };
+      return { links: Object.values(amplifyUris) };
     }
 
     const links = [];

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -17,22 +17,34 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
   }
   const amplifyUri = amplifyUriRaw.replace(/%/g, pullNumber);
   if (amplifyUri.match(/^{/)) {
-    const result = [];
+    const links = [];
+    const hiddenLinks = [];
     const amplifyUris = JSON.parse(amplifyUri);
-    for (const label of labels) {
-      if (amplifyUris[label]) {
-        result.push(`- 🔥 ${amplifyUris[label]}`);
+
+    const hasAtLeastOnePackageOrConfig = labels.some(
+      (label) => label.startsWith("package/") || label.startsWith("config/")
+    );
+
+    if (hasAtLeastOnePackageOrConfig) {
+      for (const [url] of Object.values(amplifyUris)) {
+        links.push(url);
+      }
+    } else {
+      for (const label of labels) {
+        if (amplifyUris[label]) {
+          links.push(amplifyUris[label]);
+        }
+      }
+      for (const [key, url] of Object.entries(amplifyUris)) {
+        if (!labels.includes(key)) {
+          hiddenLinks.push(url);
+        }
       }
     }
-    for (const [key, url] of Object.entries(amplifyUris)) {
-      if (!labels.includes(key)) {
-        result.push(`- 🪵 ${url}`);
-      }
-    }
-    return result;
+    return { links, hiddenLinks };
   } else if (!amplifyUri) {
     return null;
   } else {
-    return [amplifyUri];
+    return { links: [amplifyUri] };
   }
 };

--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -121,11 +121,21 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
 
   // do we have an AWS Amplify URI? If so, make sure that at least one comment
   // exists with a link to it
-  const amplifyUris = await getAmplifyURIs();
+  const {
+    links: amplifyUris,
+    hiddenLinks: hiddenAmplifyUris,
+  } = await getAmplifyURIs();
+  const hiddenAmplifyText =
+    hiddenAmplifyUris && hiddenAmplifyUris.length > 0
+      ? `\n<details>
+      <summary>More links</summary>
+      ${hiddenAmplifyUris.join("\n -")}
+      </details>`
+      : "";
   if (!amplifyUris || amplifyUris.length === 0) {
-    console.log("No AWS Amplify URI for this repository");
+    console.log("No AWS Amplify URI for this repository" + hiddenAmplifyText);
   } else {
-    console.log("AWS Amplify URIs: ", amplifyUris);
+    console.log("AWS Amplify URIs: ", amplifyUris, "hidden", hiddenAmplifyText);
     const pullNumber = pullRequest?.number || issue?.number;
     const owner =
       pullRequest?.base.repo.owner.login ||
@@ -138,7 +148,10 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
     );
 
     // add a comment with the PR
-    const body = "AWS Amplify live test URI:\n" + amplifyUris.join("\n");
+    const body =
+      "AWS Amplify live test URI:\n" +
+      amplifyUris.join("\n- ") +
+      hiddenAmplifyText;
     const previousComments = comments.filter(({ body }) =>
       body.match(/AWS Amplify live/)
     );

--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -128,8 +128,10 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
   const hiddenAmplifyText =
     hiddenAmplifyUris && hiddenAmplifyUris.length > 0
       ? `\n<details>
-      <summary>More links</summary>
+      <summary>More uris</summary>
+
       ${hiddenAmplifyUris.join("\n -")}
+
       </details>`
       : "";
   if (!amplifyUris || amplifyUris.length === 0) {

--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -122,7 +122,7 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
   // do we have an AWS Amplify URI? If so, make sure that at least one comment
   // exists with a link to it
   const amplifyUris = await getAmplifyURIs();
-  if (!amplifyUris) {
+  if (!amplifyUris || amplifyUris.length === 0) {
     console.log("No AWS Amplify URI for this repository");
   } else {
     console.log("AWS Amplify URIs: ", amplifyUris);

--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -130,7 +130,7 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
       ? `\n<details>
       <summary>More uris</summary>
 
-      ${hiddenAmplifyUris.join("\n -")}
+      - ${hiddenAmplifyUris.join("\n -")}
 
       </details>`
       : "";
@@ -152,6 +152,7 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
     // add a comment with the PR
     const body =
       "AWS Amplify live test URI:\n" +
+      "- " +
       amplifyUris.join("\n- ") +
       hiddenAmplifyText;
     const previousComments = comments.filter(({ body }) =>

--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -135,7 +135,7 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
   if (!amplifyUris || amplifyUris.length === 0) {
     console.log("No AWS Amplify URI for this repository" + hiddenAmplifyText);
   } else {
-    console.log("AWS Amplify URIs: ", amplifyUris, "hidden", hiddenAmplifyText);
+    console.log("AWS Amplify URIs: ", amplifyUris, "hidden", hiddenAmplifyUris);
     const pullNumber = pullRequest?.number || issue?.number;
     const owner =
       pullRequest?.base.repo.owner.login ||


### PR DESCRIPTION
### What does it do? Why?
Displays all monorepo amplify urls: they all are deployed, no matter what is touched in the code

### Good to know
https://mobsuccess.slack.com/archives/C05C8CVUA4A/p1692611043405489