### PR TITLE
Remove check on branch prefix when not a subbranch

### DIFF
--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -47,36 +47,6 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
       );
     }
 
-    const branches = await octokit.paginate(
-      "GET /repos/{owner}/{repo}/branches",
-      { owner, repo }
-    );
-    let oneBranchIsOk = false;
-    let nokBranch;
-    for (const { name: branchName } of branches) {
-      if (headRef === branchName) {
-        continue;
-      }
-      const prefix = headRef.substr(0, branchName.length);
-      const postfix = headRef.substr(branchName.length);
-      if (prefix === branchName && prefix.length === branchName.length) {
-        if (postfix.match(/^--[a-z]/)) {
-          oneBranchIsOk = true;
-          console.log(`Found OK branch: “${branchName}” matches “${headRef}”`);
-        } else {
-          nokBranch = branchName;
-          console.log(
-            `Found NOK branch: “${branchName}” does not match “${headRef}”`
-          );
-        }
-      }
-    }
-    if (!oneBranchIsOk && nokBranch) {
-      throw new Error(
-        `This pull request is based on the branch “${headRef}”, which starts like “${nokBranch}”. Use double dashes (“--”) to separate sub-branches. See https://app.gitbook.com/@mobsuccess/s/mobsuccess/git`
-      );
-    }
-
     if (
       commits === 1 &&
       !title.match(/^Revert ".*"/) &&


### PR DESCRIPTION
### What does it do? Why?

https://app.asana.com/0/1200175269622723/1205540785118892/f

This action was throwing an error when a branch had the same prefix as another branch.

For example, if a branch named `feature/test` exists, then I am not able to create a branch named `feature/test-2`. 
This PR removes this check. 
The naming check will still be made when on a subpr (eg a pull request having another branch as its base).
