### PR TITLE
Fix code to detect if PR title matches commit message

### DIFF
--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -51,8 +51,8 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
       commits === 1 &&
       !title.match(/^Revert ".*"/) &&
       !title.match(/^Bump .*/) &&
-      !committer === "ms-bot" &&
-      !committer === "ms-upgrade-aws"
+      committer !== "ms-bot" &&
+      committer !== "ms-upgrade-aws"
     ) {
       // we have only one commit, make sure its name match the name of the PR
       const {


### PR DESCRIPTION
### What does it do? Why?

Fix regression introduced by #26

```
> committer = "oopsie"
> !committer === "ms-bot"
false
> committer !== "ms-bot"
true
```
