### PR TITLE
Add regex to allow ticket id in PR name when it has only one commit [DEVOP-70]

### DIFF
--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -62,7 +62,10 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
         repo,
         commit_sha: headSha,
       });
-      if (commitMessage !== title) {
+      if (
+        commitMessage !== title ||
+        new RegExp(`^${title} \\[[A-Z]+-\\d+\\]$`).test(commitMessage)
+      ) {
         throw new Error(
           `This pull request has only one commit, and its message doesn't match the title of the PR. If you'd like to keep the title of the PR as it is, please add an empty commit.`
         );


### PR DESCRIPTION
Allow ticket id within ticket name that is not in the commit message
