### PR TITLE
Remove check for single commit and PR title

### DIFF
--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -11,16 +11,14 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
   if (pullRequest) {
     const {
       number: pullNumber,
-      commits,
       base: {
         ref: baseRef,
         repo: {
           owner: { login: owner },
           name: repo,
         },
-        user: { login: committer },
       },
-      head: { ref: headRef, sha: headSha },
+      head: { ref: headRef },
       title,
     } = pullRequest;
 
@@ -45,32 +43,6 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
       throw new Error(
         `The title of this pull request is invalid, please edit: “${title}”. See https://www.notion.so/mobsuccess/Git-Guidelines-41996ef576cb4f29b7737772b74289c5#4ac148fd42a04141a528a87013ea5c57`
       );
-    }
-
-    if (
-      commits === 1 &&
-      !title.match(/^Revert ".*"/) &&
-      !title.match(/^Bump .*/) &&
-      committer !== "ms-bot" &&
-      committer !== "ms-upgrade-aws"
-    ) {
-      // we have only one commit, make sure its name match the name of the PR
-      const {
-        data: { message: commitMessage },
-      } = await octokit.rest.git.getCommit({
-        owner,
-        repo,
-        commit_sha: headSha,
-      });
-      if (commitMessage !== title) {
-        throw new Error(
-          `This pull request has only one commit, and its message doesn't match the title of the PR. If you'd like to keep the title of the PR as it is, please add an empty commit.`
-        );
-      } else {
-        console.log(
-          "This pull request has only one commit, and its message matches the title of the PR."
-        );
-      }
     }
 
     // everything seems valid: add the label if it exists


### PR DESCRIPTION
### What does it do? Why?

This check is not needed now that we have this : https://github.com/mobsuccess-devops/github-mobsuccess-policy/pull/136
