### PR TITLE
Update pr & branch naming compliance

### DIFF
--- a/lib/branch.js
+++ b/lib/branch.js
@@ -1,10 +1,26 @@
 exports.isBranchNameValid = (branchName) =>
-  (!!branchName.match(
-    /^(core|feature|fix|hotfix|asset|rework|documentation|mobsuccessbot|dependabot)\/([a-z][a-z0-9._-]*)$/
-  ) ||
+  isBranchNameValid(branchName) || isBranchNameValidLegacy(branchName);
+
+function isBranchNameValidLegacy(branchName) {
+  return (
+    (!!branchName.match(
+      /^(core|feature|fix|hotfix|asset|rework|documentation|mobsuccessbot|dependabot)\/([a-z][a-z0-9._-]*)$/
+    ) ||
+      !!branchName.match(/^(mobsuccessbot)\/([a-z0-9_\-@./_-]*)$/) ||
+      !!branchName.match(/^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/) ||
+      !!branchName.match(/^revert-[0-9]+-/) ||
+      !!branchName.match(/^(rework)\/([A-Z][a-zA-Z0-9.-]*)$/)) &&
+    !branchName.match(/---/) &&
+    !branchName.match(/\/\//)
+  );
+}
+
+function isBranchNameValid(branchName) {
+  return (
+    !!branchName.match(
+      /^(feat|fix|chore|docs|refactor|change|remove|test|revert|poc|mobsuccessbot|dependabot)\/([a-z][a-z0-9._-]*)$/
+    ) ||
     !!branchName.match(/^(mobsuccessbot)\/([a-z0-9_\-@./_-]*)$/) ||
-    !!branchName.match(/^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/) ||
-    !!branchName.match(/^revert-[0-9]+-/) ||
-    !!branchName.match(/^(rework)\/([A-Z][a-zA-Z0-9.-]*)$/)) &&
-  !branchName.match(/---/) &&
-  !branchName.match(/\/\//);
+    !!branchName.match(/^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/)
+  );
+}

--- a/lib/pullRequest.js
+++ b/lib/pullRequest.js
@@ -1,7 +1,21 @@
 exports.isPullRequestTitleValid = (pullRequestName) =>
-  !!pullRequestName.match(
-    /^(Add|Clean|Fix|Improve|Remove|Update|Rework|Ignore|Bump|Switch|Migrate) .+$/
-    /* remember to edit the Notion when changing this value:
-       https://www.notion.so/mobsuccess/Git-Guidelines-41996ef576cb4f29b7737772b74289c5
-     */
-  ) || !!pullRequestName.match(/^Revert ".*"$/);
+  isPullRequestTitleValid(pullRequestName) ||
+  isPullRequestTitleValidLegacy(pullRequestName);
+
+function isPullRequestTitleValidLegacy(pullRequestName) {
+  return (
+    !!pullRequestName.match(
+      /^(Add|Clean|Fix|Improve|Remove|Update|Rework|Ignore|Bump|Switch|Migrate) .+$/
+      /* remember to edit the Notion when changing this value:
+         https://www.notion.so/mobsuccess/Git-Guidelines-41996ef576cb4f29b7737772b74289c5
+       */
+    ) || !!pullRequestName.match(/^Revert ".*"$/)
+  );
+}
+
+// commit convention: prefix([optional scope]): description
+function isPullRequestTitleValid(pullRequestName) {
+  return !!pullRequestName.match(
+    /^(feat|fix|chore|docs|refactor|change|remove|test|revert|poc)(?:\(.+\))?:.+/
+  );
+}

--- a/lib/pullRequest.js
+++ b/lib/pullRequest.js
@@ -16,6 +16,6 @@ function isPullRequestTitleValidLegacy(pullRequestName) {
 // commit convention: prefix([optional scope]): description
 function isPullRequestTitleValid(pullRequestName) {
   return !!pullRequestName.match(
-    /^(feat|fix|chore|docs|refactor|change|remove|test|revert|poc)(?:\(.+\))?:.+/
+    /^(feat|fix|chore|docs|refactor|change|remove|test|revert|poc)(?:\(.+\))?!?:.+/
   );
 }

--- a/lib/pullRequest.test.js
+++ b/lib/pullRequest.test.js
@@ -1,10 +1,19 @@
 const { isPullRequestTitleValid } = require("./pullRequest");
 
-describe("pul request", () => {
+describe("pull request", () => {
   test("recognize pull request branch names", () => {
     expect(isPullRequestTitleValid("Add feature")).toBe(true);
+    expect(isPullRequestTitleValid("chore: remove base files")).toBe(true);
+    expect(
+      isPullRequestTitleValid(
+        "fix(design-system): update color palette for accessibility compliance"
+      )
+    ).toBe(true);
   });
   test("recognize invalid branch names", () => {
     expect(isPullRequestTitleValid("add feature")).toBe(false);
+    expect(isPullRequestTitleValid("chore remove base files")).toBe(false);
+    expect(isPullRequestTitleValid("chore(): remove base files")).toBe(false);
+    expect(isPullRequestTitleValid("add: add new project")).toBe(false);
   });
 });

--- a/lib/pullRequest.test.js
+++ b/lib/pullRequest.test.js
@@ -9,11 +9,26 @@ describe("pull request", () => {
         "fix(design-system): update color palette for accessibility compliance"
       )
     ).toBe(true);
+    expect(
+      isPullRequestTitleValid(
+        "feat!: send an email to the customer when a product is shipped"
+      )
+    ).toBe(true);
+    expect(
+      isPullRequestTitleValid(
+        "feat(api)!: send an email to the customer when a product is shipped"
+      )
+    ).toBe(true);
   });
   test("recognize invalid branch names", () => {
     expect(isPullRequestTitleValid("add feature")).toBe(false);
     expect(isPullRequestTitleValid("chore remove base files")).toBe(false);
     expect(isPullRequestTitleValid("chore(): remove base files")).toBe(false);
     expect(isPullRequestTitleValid("add: add new project")).toBe(false);
+    expect(
+      isPullRequestTitleValid(
+        "feat!(api): send an email to the customer when a product is shipped"
+      )
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
### What does it do? Why?

Changes pr & branch naming compliance according to [this ADR](https://github.com/mobsuccess-devops/rfc/pull/32).
This change keeps the legacy compliance for now so that existing branches and PRs don't get rejected, it will have to be removed later.

### QA

Unit tests

