### PR TITLE
feat: automatic linear issue closing

### DIFF
--- a/.mobsuccess.yml
+++ b/.mobsuccess.yml
@@ -1,0 +1,2 @@
+linear:
+  merged_on_master_should_mark_issue_as_in_production: true


### PR DESCRIPTION
### What does it do? Why?

Automatically set linear issues to "In Production" when PRs are merged on master
