### PR TITLE
change: add all conventional commits prefixes

### DIFF
--- a/lib/branch.js
+++ b/lib/branch.js
@@ -18,7 +18,7 @@ function isBranchNameValidLegacy(branchName) {
 function isBranchNameValid(branchName) {
   return (
     !!branchName.match(
-      /^(feat|fix|chore|docs|refactor|change|remove|test|revert|poc|mobsuccessbot|dependabot)\/([a-z][a-z0-9._-]*)$/
+      /^(feat|fix|chore|docs|refactor|test|revert|ci|perf|style|build|change|remove|poc|mobsuccessbot|dependabot)\/([a-z][a-z0-9._-]*)$/
     ) ||
     !!branchName.match(/^(mobsuccessbot)\/([a-z0-9_\-@./_-]*)$/) ||
     !!branchName.match(/^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/)

--- a/lib/pullRequest.js
+++ b/lib/pullRequest.js
@@ -16,6 +16,6 @@ function isPullRequestTitleValidLegacy(pullRequestName) {
 // commit convention: prefix([optional scope]): description
 function isPullRequestTitleValid(pullRequestName) {
   return !!pullRequestName.match(
-    /^(feat|fix|chore|docs|refactor|change|remove|test|revert|poc)(?:\(.+\))?!?:.+/
+    /^(feat|fix|chore|docs|refactor|test|revert|build|ci|perf|style|change|remove|poc)(?:\(.+\))?!?:.+/
   );
 }


### PR DESCRIPTION
### What does it do? Why?

Allows for more prefixes for branch & PR prefixes
Follows this list: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum

`[
  'build',
  'chore',
  'ci',
  'docs',
  'feat',
  'fix',
  'perf',
  'refactor',
  'revert',
  'style',
  'test'
];`

### QA

Unit tests
