### PR TITLE
fix: compliance ADR #9

### DIFF
--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -29,19 +29,19 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
       !baseRef.match(/^hotfix\//)
     ) {
       throw new Error(
-        `As this pull request is based on “${baseRef}”, its name should start with “${baseRef}--”. See https://www.notion.so/mobsuccess/Git-Guidelines-41996ef576cb4f29b7737772b74289c5#f9cadc10d949498dbe38c0eed08fd4f8`
+        `As this pull request is based on “${baseRef}”, its name should start with “${baseRef}--”. See https://github.com/mobsuccess-devops/rfc/blob/master/docs/decisions/0009-convention-nommage-branch-pr.md`
       );
     }
 
     if (!isBranchNameValid(headRef)) {
       throw new Error(
-        `This pull request is based on a branch with in invalid name: “${headRef}”. See https://github.com/mobsuccess-devops/rfc/blob/master/docs/decisions/0009-convention-nommage-branch-pr.md and https://www.notion.so/mobsuccess/Git-Guidelines-41996ef576cb4f29b7737772b74289c5#f9cadc10d949498dbe38c0eed08fd4f8`
+        `This pull request is based on a branch with in invalid name: “${headRef}”. See https://github.com/mobsuccess-devops/rfc/blob/master/docs/decisions/0009-convention-nommage-branch-pr.md`
       );
     }
 
     if (!isPullRequestTitleValid(title)) {
       throw new Error(
-        `The title of this pull request is invalid, please edit: “${title}”. See https://www.notion.so/mobsuccess/Git-Guidelines-41996ef576cb4f29b7737772b74289c5#4ac148fd42a04141a528a87013ea5c57`
+        `The title of this pull request is invalid, please edit: “${title}”. See https://github.com/mobsuccess-devops/rfc/blob/master/docs/decisions/0009-convention-nommage-branch-pr.md`
       );
     }
 

--- a/lib/branch.js
+++ b/lib/branch.js
@@ -1,13 +1,5 @@
 function isBranchNameValid(branchName) {
   return (
-    // The following are the older branch prefixes, that are still valid, with
-    // discussions pending on the ADR #9 with a PR #35 still active at the time
-    // of writing, to maybe deprecate them. In the meantime we still have to
-    // allow branches using these prefixes, as no active ADR disallows their
-    // use.
-    !!branchName.match(
-      /^(core|feature|fix|hotfix|asset|rework|documentation)\/([a-z][a-z0-9._-]*)$/
-    ) ||
     !!branchName.match(
       /^(feat|fix|chore|docs|refactor|test|revert|ci|perf|style|build|change|remove|poc|mobsuccessbot|dependabot)\/([a-z][a-z0-9._-]*)$/
     ) ||

--- a/lib/branch.test.js
+++ b/lib/branch.test.js
@@ -20,14 +20,14 @@ describe("branch", () => {
   });
   // Some tests were commented out, see #92.
   test.each([
-    // "core/foo--bar",
-    // "core/foo--bar--z",
+    "core/foo--bar",
+    "core/foo--bar--z",
     "foo/foo-bar",
-    // "feature/foo",
-    // "hotfix/foo",
-    // "core/foo",
-    // "asset/foo",
-    // "documentation/foo",
+    "feature/foo",
+    "hotfix/foo",
+    "core/foo",
+    "asset/foo",
+    "documentation/foo",
     "chore",
     "chore/",
     "chore/FOO",


### PR DESCRIPTION
### What does it do? Why?

Fixes compliance with https://github.com/mobsuccess-devops/rfc/blob/master/docs/decisions/0009-convention-nommage-branch-pr.md

Additionally, I have modified the Notion page to point to the ADR.
