### PR TITLE
change: accept github revert PR name [DEVOP-263]

### DIFF
--- a/lib/pullRequest.js
+++ b/lib/pullRequest.js
@@ -1,6 +1,8 @@
 function isPullRequestTitleValid(pullRequestName) {
-  return !!pullRequestName.match(
-    /^(feat|fix|chore|docs|refactor|test|revert|build|ci|perf|style|change|remove|poc)(?:\(.+\))?!?:.+/
+  return (
+    !!pullRequestName.match(
+      /^(feat|fix|chore|docs|refactor|test|revert|build|ci|perf|style|change|remove|poc)(?:\(.+\))?!?:.+/
+    ) || !!pullRequestName.match(/^revert .+/)
   );
 }
 

--- a/lib/pullRequest.test.js
+++ b/lib/pullRequest.test.js
@@ -6,6 +6,7 @@ describe("pull request", () => {
     "fix(design-system): update color palette for accessibility compliance",
     "feat!: send an email to the customer when a product is shipped",
     "feat(api)!: send an email to the customer when a product is shipped",
+    'revert "feat: add 3 freelance users " [PHP-539]',
   ])("Test pull request title %s should be valid", (title) => {
     expect(isPullRequestTitleValid(title)).toBe(true);
   });


### PR DESCRIPTION
### What does it do? Why?

allows GH revert PR names (starting with `revert`)

### QA

UTs