### PR TITLE
feat(branch): allow renovate prefix [FRONT-1897]

### DIFF
--- a/lib/branch.js
+++ b/lib/branch.js
@@ -5,7 +5,8 @@ function isBranchNameValid(branchName) {
     ) ||
     !!branchName.match(/^revert-([0-9]+)-([a-z0-9_\-@./_-]*)$/) ||
     !!branchName.match(/^(mobsuccessbot)\/([a-z0-9_\-@./_-]*)$/) ||
-    !!branchName.match(/^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/)
+    !!branchName.match(/^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/) ||
+    !!branchName.match(/^(renovate)\/([a-z0-9_\-@./_-]*)$/)
   );
 }
 

--- a/lib/branch.test.js
+++ b/lib/branch.test.js
@@ -17,6 +17,9 @@ describe("branch", () => {
     "dependabot/foo",
     "dependabot/npm_and_yarn/axios-0.21.1",
     "dependabot/npm_and_yarn/axios-0.21.1",
+    "renovate/configure",
+    "renovate/tanstack-table-monorepo",
+    "renovate/mobsuccess-devops-dlpo-react-client-1.x",
   ])("Test branch %s should be valid", (branch) => {
     expect(isBranchNameValid(branch)).toBe(true);
   });


### PR DESCRIPTION
### What does it do? Why?

Allow branches that start with `renovate/`