### PR TITLE
fix: amplify uris for package

### DIFF
--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -25,9 +25,9 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
 
     if (hasAtLeastOnePackageOrConfig) {
       return {
-        links: Object.entries(amplifyUris).reduce((acc, [label, url]) => {
-          return { ...acc, label, url };
-        }, {}),
+        links: Object.entries(amplifyUris).map(([label, url]) => {
+          return { label, url };
+        }),
       };
     }
 


### PR DESCRIPTION
### What does it do? Why?

