### PR TITLE
fix: which links ends up in linear preview [DEVOP-665]

### DIFF
--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -23,30 +23,22 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
       (label) => label.startsWith("packages/") || label.startsWith("configs/")
     );
 
-    if (hasAtLeastOnePackageOrConfig) {
+    const allLinks = Object.entries(amplifyUris).map(([label, url]) => {
+      const hasLabel = labels.some((l) => label.includes(l));
       return {
-        links: Object.entries(amplifyUris).map(([label, url]) => {
-          return { label, url };
-        }),
+        label,
+        url,
+        isVisibleInComment: hasAtLeastOnePackageOrConfig || hasLabel,
+        hasPreview: hasLabel,
       };
-    }
-
-    const links = [];
-    const hiddenLinks = [];
-    for (const label of labels) {
-      if (amplifyUris[label]) {
-        links.push({ label, url: amplifyUris[label] });
-      }
-    }
-    for (const [key, url] of Object.entries(amplifyUris)) {
-      if (!labels.includes(key)) {
-        hiddenLinks.push(url);
-      }
-    }
-    return { links, hiddenLinks };
+    });
+    return {
+      links: allLinks.filter((l) => l.isVisibleInComment),
+      hiddenLinks: allLinks.filter((l) => !l.isVisibleInComment),
+    };
   } else if (!amplifyUri) {
     return {};
   } else {
-    return { links: [amplifyUri] };
+    return { links: [{ url: amplifyUri, hasPreview: true }] };
   }
 };

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -20,11 +20,15 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
     const amplifyUris = JSON.parse(amplifyUri);
 
     const hasAtLeastOnePackageOrConfig = labels.some(
-      (label) => label.startsWith("packages/") || label.startsWith("configs/")
+      (label) => label.startsWith("packages/") || label.startsWith("configs/"),
     );
 
     const allLinks = Object.entries(amplifyUris).map(([label, url]) => {
-      const hasLabel = labels.some((l) => label.includes(l));
+      console.log("comparing labels", labels, label);
+      const hasLabel = labels.some((l) => {
+        console.log("comparing", l, label, label.includes(l));
+        return label.includes(l);
+      });
       return {
         label,
         url,

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -20,7 +20,7 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
     const amplifyUris = JSON.parse(amplifyUri);
 
     const hasAtLeastOnePackageOrConfig = labels.some(
-      (label) => label.startsWith("packages/") || label.startsWith("configs/"),
+      (label) => label.startsWith("packages/") || label.startsWith("configs/")
     );
 
     const allLinks = Object.entries(amplifyUris).map(([label, url]) => {

--- a/lib/actions/amplify.js
+++ b/lib/actions/amplify.js
@@ -24,11 +24,7 @@ exports.getAmplifyURIs = async function getAmplifyURI() {
     );
 
     const allLinks = Object.entries(amplifyUris).map(([label, url]) => {
-      console.log("comparing labels", labels, label);
-      const hasLabel = labels.some((l) => {
-        console.log("comparing", l, label, label.includes(l));
-        return label.includes(l);
-      });
+      const hasLabel = labels.some((l) => label.includes(l));
       return {
         label,
         url,

--- a/lib/actions/pullRequest.js
+++ b/lib/actions/pullRequest.js
@@ -98,7 +98,15 @@ exports.validatePR = async function validatePR({ pullRequest, issue }) {
       "AWS Amplify live test URI:\n" +
       "- " +
       amplifyUris
-        .map((elt) => `[${elt.label?.split("/")?.pop()} preview](${elt.url})`)
+        .map(
+          (elt) =>
+            `[${[
+              elt.label?.split("/")?.pop(),
+              elt.hasPreview ? " preview" : undefined, // any link with "preview" in the label will be displayed in the linked linear issue
+            ]
+              .filter(Boolean)
+              .join(" ")}](${elt.url})`
+        )
         .join("\n- ") +
       hiddenAmplifyText;
     const previousComments = comments.filter(({ body }) =>


### PR DESCRIPTION
Fix which links appears in linear preview (should not include all links when package label is present)
