### PR TITLE
chore: upgrade ubuntu runners to v24 [FTTECH-256]

### DIFF
--- a/sample/workflows/closed.yml
+++ b/sample/workflows/closed.yml
@@ -8,7 +8,7 @@ jobs:
   ZapierReviewRequestedPurpleHeart:
     if: github.event.pull_request.merged == true
     name: "Zapier Purple Heart"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 1
     steps:
       - name: "Sync emoji in #mobsuccess-review-requested"
@@ -17,7 +17,7 @@ jobs:
   ZapierReviewRequestedRedCross:
     if: github.event.pull_request.merged == false
     name: "Zapier Red Cross"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 1
     steps:
       - name: "Sync emoji in #mobsuccess-review-requested"
@@ -26,7 +26,7 @@ jobs:
   CommentSubPRs:
     if: github.event.pull_request.merged == true
     name: "Comment rebase --onto on Sub PRs"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     steps:
       - uses: mobsuccess-devops/github-actions-mobsuccess@master

--- a/sample/workflows/mobsuccess.yml
+++ b/sample/workflows/mobsuccess.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   MobsuccessPRCompliance:
     name: "Mobsuccess PR Compliance"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     steps:
       - uses: mobsuccess-devops/github-actions-mobsuccess@master


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to use a newer version of the Ubuntu runner. The changes are made across multiple jobs in two workflow files.

Updates to Ubuntu runner version:

* Updated the `runs-on` field for `ZapierReviewRequestedPurpleHeart`, `ZapierReviewRequestedRedCross`, and `CommentSubPRs` jobs from `ubuntu-20.04` to `ubuntu-24.04`.
* Updated the `runs-on` field for the `MobsuccessPRCompliance` job from `ubuntu-20.04` to `ubuntu-24.04`.