### PR TITLE
feat: disable npm updater

### DIFF
--- a/.mobsuccess.yml
+++ b/.mobsuccess.yml
@@ -1,2 +1,6 @@
+policy:
+  skip-updaters:
+    - npm
+
 linear:
   merged_on_master_should_mark_issue_as_in_production: true


### PR DESCRIPTION
This pull request includes a small change to the `.mobsuccess.yml` file. The change adds a policy to skip certain updaters, specifically `npm`.

* [`.mobsuccess.yml`](diffhunk://#diff-cc8f4bbcfdd8bb94237b941e25222597112f9bf097ff7635bc0cdb9345e29558R1-R4): Added a policy to skip the `npm` updater.