### PR TITLE
feat(branch-name): allow crowdin branch name [EXP-2523]

### DIFF
--- a/lib/branch.js
+++ b/lib/branch.js
@@ -1,13 +1,14 @@
 function isBranchNameValid(branchName) {
   return (
-    !!branchName.match(
-      /^(hotfix|feat|fix|chore|docs|refactor|test|revert|ci|perf|style|build|change|remove|poc|mobsuccessbot|dependabot)\/([a-z][a-z0-9._-]*)$/
+    /^(hotfix|feat|fix|chore|docs|refactor|test|revert|ci|perf|style|build|change|remove|poc|mobsuccessbot|dependabot)\/([a-z][a-z0-9._-]*)$/.test(
+      branchName
     ) ||
-    !!branchName.match(/^revert-([0-9]+)-([a-z0-9_\-@./_-]*)$/) ||
-    !!branchName.match(/^(mobsuccessbot)\/([a-z0-9_\-@./_-]*)$/) ||
-    !!branchName.match(/^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/) ||
-    !!branchName.match(/^(renovate)\/([a-z0-9_\-@./_-]*)$/) ||
-    !!branchName.match(/^(copilot)\/([a-z0-9_\-@./_-]*)$/)
+    /^revert-([0-9]+)-([a-z0-9_\-@./_-]*)$/.test(branchName) ||
+    /^(mobsuccessbot)\/([a-z0-9_\-@./_-]*)$/.test(branchName) ||
+    /^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/.test(branchName) ||
+    /^(renovate)\/([a-z0-9_\-@./_-]*)$/.test(branchName) ||
+    /^(copilot)\/([a-z0-9_\-@./_-]*)$/.test(branchName) ||
+    /^crowdin\/update-translations$/.test(branchName)
   );
 }
 

--- a/lib/branch.test.js
+++ b/lib/branch.test.js
@@ -20,6 +20,7 @@ describe("branch", () => {
     "renovate/configure",
     "renovate/tanstack-table-monorepo",
     "renovate/mobsuccess-devops-dlpo-react-client-1.x",
+    "crowdin/update-translations",
   ])("Test branch %s should be valid", (branch) => {
     expect(isBranchNameValid(branch)).toBe(true);
   });
@@ -42,6 +43,7 @@ describe("branch", () => {
     "rework/fooDriveFooterBar",
     "chore//foo",
     "revert-change/brevo-emailing",
+    "crowdin/not-update-translations",
   ])("Test branch %s should be invalid", (branch) => {
     expect(isBranchNameValid(branch)).toBe(false);
   });


### PR DESCRIPTION
### What does it do? Why?
Adds support for `crowdin/update-translations` branch pattern and refactors regex validation to use `.test()` method for better performance and readability.

### Scope
- Updates branch name validation regex to include crowdin translation updates
- Refactors existing regex patterns to use `.test()` instead of `.match()` for cleaner code
- Adds corresponding test cases for the new branch pattern

### QA
- All existing branch patterns continue to work
- New crowdin pattern is properly validated
- Invalid crowdin patterns are correctly rejected

### Test URL
N/A - Backend validation changes
