### PR TITLE
chore: add hadolint rules [FTTECH-3202]

### DIFF
--- a/sample/workflows/dockerfile.yml
+++ b/sample/workflows/dockerfile.yml
@@ -26,5 +26,5 @@ jobs:
           dockerfile: "Dockerfile*"
           recursive: true
           format: tty
-          override-info: DL3008,DL3018
+          override-info: DL3008,DL3018,DL3033,DL3037,DL3041,DL4006
           failure-threshold: warning


### PR DESCRIPTION
This pull request makes a small update to the Dockerfile linting configuration in the workflow file. The change expands the list of overridden linting rules to include several additional rule codes, likely to suppress or customize warnings for those specific rules.

- Expanded the `override-info` list in the `dockerfile.yml` workflow to include [DL3033](https://github.com/hadolint/hadolint/wiki/DL3033), [DL3037](https://github.com/hadolint/hadolint/wiki/DL3037), [DL3041](https://github.com/hadolint/hadolint/wiki/DL3041), and [DL4006](https://github.com/hadolint/hadolint/wiki/DL4006), in addition to the previously overridden [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) and [DL3018](https://github.com/hadolint/hadolint/wiki/DL3018).