### PR TITLE
chore: remove hadolint rules as info [FTTECH-3205]

### DIFF
--- a/sample/workflows/dockerfile.yml
+++ b/sample/workflows/dockerfile.yml
@@ -26,5 +26,4 @@ jobs:
           dockerfile: "Dockerfile*"
           recursive: true
           format: tty
-          override-info: DL3008,DL3018
           failure-threshold: warning


### PR DESCRIPTION
This pull request makes a minor update to the Dockerfile linter configuration in the workflow file by removing the `override-info` setting. This change simplifies the configuration and ensures that all linter warnings and errors are handled according to the default rules.