### PR TITLE
feat: allow mixed case in claude branch names

### DIFF
--- a/lib/branch.js
+++ b/lib/branch.js
@@ -8,7 +8,7 @@ function isBranchNameValid(branchName) {
     /^(dependabot)\/([a-z][a-zA-Z0-9./_-]*)$/.test(branchName) ||
     /^(renovate)\/([a-z0-9_\-@./_-]*)$/.test(branchName) ||
     /^(copilot)\/([a-z0-9_\-@./_-]*)$/.test(branchName) ||
-    /^(claude)\/([a-z0-9_\-@./_-]*)$/.test(branchName) ||
+    /^(claude)\/([a-zA-Z0-9_\-@./_-]*)$/.test(branchName) ||
     /^crowdin\/update-translations$/.test(branchName)
   );
 }

--- a/lib/branch.test.js
+++ b/lib/branch.test.js
@@ -22,6 +22,10 @@ describe("branch", () => {
     "renovate/mobsuccess-devops-dlpo-react-client-1.x",
     "crowdin/update-translations",
     "claude/foo",
+    "claude/name-of-the-feature",
+    "claude/name-of-the-feature-xxxxx",
+    "claude/name-of-the-feature-XXXXX",
+    "claude/name-of-the-feature-11111",
   ])("Test branch %s should be valid", (branch) => {
     expect(isBranchNameValid(branch)).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Allow mixed case characters in `claude/` branch names
- Supports the format `claude/[name]-[id]` where the ID can contain uppercase letters (e.g., `claude/add-question-difficulty-jkWJz`)

### What does it do? Why?

Updates the branch name validation regex for `claude/` prefixed branches to accept uppercase letters (`a-zA-Z` instead of `a-z`).

This enables Claude Code to create branches with auto-generated IDs that may contain mixed case characters.

## Test plan

- [x] Added test cases for `claude/name-of-the-feature-XXXXX` format
- [x] All existing tests pass
- [x] 100% code coverage maintained