### PR TITLE
chore(dockerfile): filtrer le lint hadolint par paths [FTTECH-10638]

### DIFF
--- a/sample/workflows/dockerfile.yml
+++ b/sample/workflows/dockerfile.yml
@@ -9,10 +9,16 @@ on:
       - opened
       - synchronize
       - reopened
+    paths:
+      - "**/Dockerfile*"
+      - ".github/workflows/dockerfile.yml"
   push:
     branches:
       - master
       - prod
+    paths:
+      - "**/Dockerfile*"
+      - ".github/workflows/dockerfile.yml"
 
 jobs:
   dockerfile:


### PR DESCRIPTION
## What Does It Do?

Ajoute un filtre `paths` sur les triggers `pull_request` et `push` du workflow Dockerfile (lint hadolint) distribué dans `sample/workflows/dockerfile.yml` :

```yaml
paths:
  - "**/Dockerfile*"
  - ".github/workflows/dockerfile.yml"
```

Le job hadolint ne se déclenche plus sur les PR/push qui ne modifient aucun Dockerfile.

## Context

Le snippet était déclenché sur **tous** les `pull_request`/`push`, donc le lint tournait à vide sur des PR sans rapport (constaté sur une PR docs-only de PanoramAI : [panoramai#1515](https://github.com/mobsuccess-devops/panoramai/pull/1515)). `matchFiles: "**/Dockerfile*"` côté policy ne gère que l'installation du workflow, pas son déclenchement — le filtre `paths` doit vivre dans le snippet.

Le trigger `merge_group` reste **non filtré** : les required checks évalués en merge queue continuent de tourner (un required check filtré par `paths` resterait pending et bloquerait le merge). Même pattern que `sample/workflows/mobsuccess.yml`.

Propagation : une fois mergé, le bot policy re-synchronise le bloc `DO NOT EDIT` de `dockerfile.yml` dans chaque repo.

## Test Plan

- [ ] Vérifier qu'une PR ne touchant aucun Dockerfile ne déclenche plus le job « Dockerfile »
- [ ] Vérifier qu'une PR modifiant un `Dockerfile` (à n'importe quel niveau) déclenche bien le lint
- [ ] Vérifier que le job tourne toujours en merge queue (merge_group)

Closes FTTECH-10638
