### PR TITLE
chore: upgrade dockerfile workflow to actions/checkout@v7

### DIFF
--- a/sample/workflows/dockerfile.yml
+++ b/sample/workflows/dockerfile.yml
@@ -19,7 +19,7 @@ jobs:
     name: Dockerfile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Dockerfile lint
         uses: hadolint/hadolint-action@v3.3.0
         with:


### PR DESCRIPTION
Upgrade `actions/checkout` from v6 to v7 in the `sample/workflows/dockerfile.yml` sample workflow.

v7 est la dernière release majeure (v7.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)