### PR TITLE
feat(compliance): block commits that replace a gitignored directory [FTTECH-12174]

### DIFF
--- a/sample/workflows/mobsuccess.yml
+++ b/sample/workflows/mobsuccess.yml
@@ -52,16 +52,41 @@ jobs:
           set -uo pipefail
           fail=0
 
+          # Fail closed. This guard stands in front of an irreversible deletion, so
+          # it must never report success because git itself failed: an empty result
+          # from a command that errored would otherwise read as "nothing to flag".
+          # `set -e` is deliberately not used — check-ignore's non-zero exit is the
+          # predicate this script is built on — so each call is checked explicitly.
+          die() { echo "::error::$1"; exit 1; }
+
+          diff_out=$(git diff --raw --no-renames --diff-filter=AMT "$BASE_SHA...$HEAD_SHA") \
+            || die "Cannot diff $BASE_SHA...$HEAD_SHA. Refusing to pass without having checked."
+          tree_out=$(git ls-tree -r --name-only "$HEAD_SHA") \
+            || die "Cannot list the tree at $HEAD_SHA. Refusing to pass without having checked."
+
           # Probe sandbox: HEAD's .gitignore files and nothing else. Probing cannot
           # happen in the real worktree — once the symlink exists on disk, git
           # refuses to resolve a pathspec "beyond a symbolic link".
           sandbox=$(mktemp -d)
           trap 'rm -rf "$sandbox"' EXIT
           git -C "$sandbox" init -q .
+
+          # Only ignore rules committed to the repo may decide the verdict. A
+          # runner's global core.excludesFile and the info/exclude the init
+          # template writes both reach --no-index, and would make the result
+          # depend on the machine rather than on the PR.
+          : > "$sandbox/.git/info/exclude"
+          ignored() {
+            git -c core.excludesFile=/dev/null -C "$sandbox" \
+              check-ignore -q --no-index -- "$1"
+          }
+
           while IFS= read -r gi; do
+            [ -n "$gi" ] || continue
             mkdir -p "$sandbox/$(dirname "$gi")"
-            git show "$HEAD_SHA:$gi" > "$sandbox/$gi" 2>/dev/null
-          done < <(git ls-tree -r --name-only "$HEAD_SHA" | grep -E '(^|/)\.gitignore$' || true)
+            git show "$HEAD_SHA:$gi" > "$sandbox/$gi" \
+              || die "Cannot read $gi at $HEAD_SHA. Refusing to pass without having checked."
+          done < <(printf '%s\n' "$tree_out" | grep -E '(^|/)\.gitignore$')
 
           while IFS= read -r line; do
             [ -n "$line" ] || continue
@@ -74,18 +99,25 @@ jobs:
             # so negations, nesting and precedence are handled for free: children
             # of the path are ignored, the path itself is not. check-ignore uses
             # lstat, so a symlink to a real directory still reads as "not a dir".
-            if ! git -C "$sandbox" check-ignore -q --no-index -- "$path" \
-               && git -C "$sandbox" check-ignore -q --no-index -- "$path/__probe__"; then
+            if ! ignored "$path" && ignored "$path/__probe__"; then
               kind="file"
-              [ "$mode" = "120000" ] && kind="symlink -> $(git show "$HEAD_SHA:$path")"
+              if [ "$mode" = "120000" ]; then
+                t=$(git show "$HEAD_SHA:$path") \
+                  || die "Cannot read the symlink target of $path at $HEAD_SHA."
+                kind="symlink -> $t"
+              fi
               echo "::error file=$path::Tracking '$path' ($kind) will DELETE the ignored directory of the same name when this is merged or checked out — its contents are gitignored but the path itself is not."
               fail=1
             fi
 
             # Independent rule: a tracked symlink must not escape the worktree.
             if [ "$mode" = "120000" ]; then
-              target=$(git show "$HEAD_SHA:$path")
-              resolved=$(python3 -c 'import posixpath,sys; print(posixpath.normpath(posixpath.join(posixpath.dirname(sys.argv[1]), sys.argv[2])))' "$path" "$target")
+              target=$(git show "$HEAD_SHA:$path") \
+                || die "Cannot read the symlink target of $path at $HEAD_SHA."
+              # normpath is pure string work: it must not resolve against the
+              # worktree, where the symlink already exists.
+              resolved=$(python3 -c 'import posixpath,sys; print(posixpath.normpath(posixpath.join(posixpath.dirname(sys.argv[1]), sys.argv[2])))' "$path" "$target") \
+                || die "Cannot resolve the symlink target of $path."
               escape=0
               case "$target" in /*) escape=1 ;; esac
               case "$resolved" in ..*) escape=1 ;; esac
@@ -94,7 +126,7 @@ jobs:
                 fail=1
               fi
             fi
-          done < <(git diff --raw --no-renames --diff-filter=AMT "$BASE_SHA...$HEAD_SHA")
+          done < <(printf '%s\n' "$diff_out")
 
           if [ "$fail" -ne 0 ]; then
             echo ""

--- a/sample/workflows/mobsuccess.yml
+++ b/sample/workflows/mobsuccess.yml
@@ -55,20 +55,39 @@ jobs:
           # Fail closed. This guard stands in front of an irreversible deletion, so
           # it must never report success because git itself failed: an empty result
           # from a command that errored would otherwise read as "nothing to flag".
-          # `set -e` is deliberately not used — check-ignore's non-zero exit is the
-          # predicate this script is built on — so each call is checked explicitly.
-          die() { echo "::error::$1"; exit 1; }
+          # The runner's default shell is `bash -e`, but nothing here leans on that:
+          # check-ignore's non-zero exit is this script's core predicate, so every
+          # git call whose silence would be mistaken for success is checked by hand.
+          #
+          # printf rather than echo throughout: some shells expand backslash escapes
+          # in echo, which would turn a literal \n inside a path back into a real
+          # newline and undo the escaping below.
+          die() { printf '%s\n' "::error::$(esc "$1")"; exit 1; }
 
-          diff_out=$(git diff --raw --no-renames --diff-filter=AMT "$BASE_SHA...$HEAD_SHA") \
+          # GitHub parses workflow commands one line at a time, so every value
+          # interpolated into one is escaped: a path may legally contain a newline,
+          # which would otherwise let it forge a second command. Property values
+          # need `:` and `,` too, as those delimit the property list.
+          esc() { local s=${1//'%'/%25}; s=${s//$'\r'/%0D}; s=${s//$'\n'/%0A}; printf '%s' "$s"; }
+          esc_prop() { local s; s=$(esc "$1"); s=${s//:/%3A}; s=${s//,/%2C}; printf '%s' "$s"; }
+
+          work=$(mktemp -d)
+          trap 'rm -rf "$work"' EXIT
+
+          # -z keeps paths literal. Without it git C-quotes any path containing a
+          # control character, and that quoted string matches neither the repo nor
+          # the ignore rules — so a crafted path could slip past the check. Literal
+          # paths are why the escaping above is required, not optional.
+          git diff --raw -z --no-renames --diff-filter=AMT "$BASE_SHA...$HEAD_SHA" > "$work/diff" \
             || die "Cannot diff $BASE_SHA...$HEAD_SHA. Refusing to pass without having checked."
-          tree_out=$(git ls-tree -r --name-only "$HEAD_SHA") \
+          git ls-tree -r -z --name-only "$HEAD_SHA" > "$work/tree" \
             || die "Cannot list the tree at $HEAD_SHA. Refusing to pass without having checked."
 
           # Probe sandbox: HEAD's .gitignore files and nothing else. Probing cannot
           # happen in the real worktree — once the symlink exists on disk, git
           # refuses to resolve a pathspec "beyond a symbolic link".
-          sandbox=$(mktemp -d)
-          trap 'rm -rf "$sandbox"' EXIT
+          sandbox="$work/sandbox"
+          mkdir -p "$sandbox"
           git -C "$sandbox" init -q .
 
           # Only ignore rules committed to the repo may decide the verdict. A
@@ -81,17 +100,17 @@ jobs:
               check-ignore -q --no-index -- "$1"
           }
 
-          while IFS= read -r gi; do
-            [ -n "$gi" ] || continue
+          while IFS= read -r -d '' gi; do
+            case "$gi" in .gitignore|*/.gitignore) ;; *) continue ;; esac
             mkdir -p "$sandbox/$(dirname "$gi")"
             git show "$HEAD_SHA:$gi" > "$sandbox/$gi" \
               || die "Cannot read $gi at $HEAD_SHA. Refusing to pass without having checked."
-          done < <(printf '%s\n' "$tree_out" | grep -E '(^|/)\.gitignore$')
+          done < "$work/tree"
 
-          while IFS= read -r line; do
-            [ -n "$line" ] || continue
-            mode=$(printf '%s' "$line" | awk '{print $2}')
-            path=$(printf '%s' "$line" | cut -f2-)
+          # --raw -z emits ":<modes> <shas> <status>" and the path as two separate
+          # NUL-terminated records, so read them in pairs.
+          while IFS= read -r -d '' meta && IFS= read -r -d '' path; do
+            mode=$(printf '%s' "$meta" | awk '{print $2}')
             # A tracked directory is normal; only blobs and symlinks land at a path.
             case "$mode" in 040000|000000) continue ;; esac
 
@@ -106,7 +125,7 @@ jobs:
                   || die "Cannot read the symlink target of $path at $HEAD_SHA."
                 kind="symlink -> $t"
               fi
-              echo "::error file=$path::Tracking '$path' ($kind) will DELETE the ignored directory of the same name when this is merged or checked out — its contents are gitignored but the path itself is not."
+              printf '%s\n' "::error file=$(esc_prop "$path")::$(esc "Tracking '$path' ($kind) will DELETE the ignored directory of the same name when this is merged or checked out — its contents are gitignored but the path itself is not.")"
               fail=1
             fi
 
@@ -122,11 +141,11 @@ jobs:
               case "$target" in /*) escape=1 ;; esac
               case "$resolved" in ..*) escape=1 ;; esac
               if [ "$escape" -eq 1 ]; then
-                echo "::error file=$path::Symlink '$path' -> '$target' points outside the repository. Tracked symlinks must stay repo-internal."
+                printf '%s\n' "::error file=$(esc_prop "$path")::$(esc "Symlink '$path' -> '$target' points outside the repository. Tracked symlinks must stay repo-internal.")"
                 fail=1
               fi
             fi
-          done < <(printf '%s\n' "$diff_out")
+          done < "$work/diff"
 
           if [ "$fail" -ne 0 ]; then
             echo ""

--- a/sample/workflows/mobsuccess.yml
+++ b/sample/workflows/mobsuccess.yml
@@ -28,3 +28,82 @@ jobs:
           amplify-uri: ${{ secrets.AWS_AMPLIFY_URI }}${{ vars.AWS_AMPLIFY_URI }}
           storybook-amplify-uri: ${{ secrets.AWS_STORYBOOK_AMPLIFY_URI }}${{ vars.AWS_STORYBOOK_AMPLIFY_URI }}
           action: "validate-pr"
+
+      # blob:none keeps this cheap even on the monolith: full commit graph (needed
+      # for the base...head merge base), file contents fetched only on demand.
+      - name: Checkout
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      # A .gitignore pattern that only reaches INSIDE a directory (dir/, dir/*,
+      # dir/**) does not ignore a symlink or file at `dir` itself, so `git add -A`
+      # stages it. Merging that commit makes git delete the ignored directory to
+      # put the tracked entry in its place — silently, with no trash and no reflog
+      # for untracked content. Already happened in the org: panoramai#433.
+      - name: Ignored directory replacement
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          fail=0
+
+          # Probe sandbox: HEAD's .gitignore files and nothing else. Probing cannot
+          # happen in the real worktree — once the symlink exists on disk, git
+          # refuses to resolve a pathspec "beyond a symbolic link".
+          sandbox=$(mktemp -d)
+          trap 'rm -rf "$sandbox"' EXIT
+          git -C "$sandbox" init -q .
+          while IFS= read -r gi; do
+            mkdir -p "$sandbox/$(dirname "$gi")"
+            git show "$HEAD_SHA:$gi" > "$sandbox/$gi" 2>/dev/null
+          done < <(git ls-tree -r --name-only "$HEAD_SHA" | grep -E '(^|/)\.gitignore$' || true)
+
+          while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            mode=$(printf '%s' "$line" | awk '{print $2}')
+            path=$(printf '%s' "$line" | cut -f2-)
+            # A tracked directory is normal; only blobs and symlinks land at a path.
+            case "$mode" in 040000|000000) continue ;; esac
+
+            # Hole test, decided by git's own matcher rather than pattern parsing,
+            # so negations, nesting and precedence are handled for free: children
+            # of the path are ignored, the path itself is not. check-ignore uses
+            # lstat, so a symlink to a real directory still reads as "not a dir".
+            if ! git -C "$sandbox" check-ignore -q --no-index -- "$path" \
+               && git -C "$sandbox" check-ignore -q --no-index -- "$path/__probe__"; then
+              kind="file"
+              [ "$mode" = "120000" ] && kind="symlink -> $(git show "$HEAD_SHA:$path")"
+              echo "::error file=$path::Tracking '$path' ($kind) will DELETE the ignored directory of the same name when this is merged or checked out — its contents are gitignored but the path itself is not."
+              fail=1
+            fi
+
+            # Independent rule: a tracked symlink must not escape the worktree.
+            if [ "$mode" = "120000" ]; then
+              target=$(git show "$HEAD_SHA:$path")
+              resolved=$(python3 -c 'import posixpath,sys; print(posixpath.normpath(posixpath.join(posixpath.dirname(sys.argv[1]), sys.argv[2])))' "$path" "$target")
+              escape=0
+              case "$target" in /*) escape=1 ;; esac
+              case "$resolved" in ..*) escape=1 ;; esac
+              if [ "$escape" -eq 1 ]; then
+                echo "::error file=$path::Symlink '$path' -> '$target' points outside the repository. Tracked symlinks must stay repo-internal."
+                fail=1
+              fi
+            fi
+          done < <(git diff --raw --no-renames --diff-filter=AMT "$BASE_SHA...$HEAD_SHA")
+
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "Remove the offending entry from the commit: git rm --cached <path>"
+            echo ""
+            echo "Do NOT 'fix' the .gitignore instead: 'dir/*' plus '!dir/keep' cannot be"
+            echo "rewritten as a bare 'dir', because git will not re-include anything inside"
+            echo "an ignored directory. A bare 'dir' is correct only where there is no"
+            echo "negation to preserve."
+            exit 1
+          fi
+          echo "No ignored-directory replacement detected."


### PR DESCRIPTION
## What Does It Do?

Adds two steps to the **existing** `MobsuccessPRCompliance` job that fail a PR which tracks an entry at a path whose *contents* are gitignored but whose own path is not.

A `.gitignore` pattern that only reaches inside a directory — `dir/`, `dir/*`, `dir/**` — does not ignore a symlink or file at `dir` itself. Git sees a symlink as a file, and a trailing slash matches directories only, so `git add -A` stages it with no warning. On merge, git must place the tracked entry at that path, so it **deletes the whole ignored directory** to make room. No trash, no reflog for untracked content.

Reproduced locally — `data/`, `data/*`, `data/**` and `/data/` all destroy the directory; only a bare `data` survives.

Two independent rules:

1. an added blob/symlink whose children are gitignored but whose own path is not (the destructive shape);
2. a tracked symlink whose target escapes the worktree.

Detection asks `git check-ignore` rather than parsing patterns, so negations, nesting and precedence are handled by git itself. Probing happens in a sandbox holding only HEAD's `.gitignore` files, because once the symlink exists on disk git refuses to resolve a pathspec `beyond a symbolic link`.

## Context

**This already happened here.** `panoramai#433` committed a machine-local `frontend/node_modules` symlink straight through a `frontend/node_modules/` pattern, via `git add -A` during a review fix. Cleaned up manually in `panoramai#440` (FTGENAI-872). It was only caught because a dangling `node_modules` breaks `npm install` loudly — over a data directory the deletion would have been silent.

Org-wide audit: **4,708 hole paths across 248 repos**. None is armed today, but 18.7 GB of local data sits on those paths, and the monolith has twelve such patterns over production content (`/app/upload/`, `/www/img_apps/`, client logo directories).

Fixing patterns instead would mean 4,708 edits and still would not close the class: `dir/*` plus `!dir/keep` **cannot** be rewritten as a bare `dir`, because git will not re-include anything inside an ignored directory.

### Why a step and not a new job

GitHub rounds billing to the minute **per job**. A separate job would mean a fresh runner and a fresh 1-minute floor on every PR run — 2,647 PRs in the last 30 days, more counting `synchronize` — for roughly one second of work. As a step in a job that already runs, the marginal cost is ~0, and the status context stays `Mobsuccess PR Compliance`, which is already in `requiredJobNames`. **No policy-repo change and no opt-in PR are needed**: the `mobsuccess` policy declares neither `matchFiles` nor `matchKeys`, so this workflow is already injected into all 367 repos.

The script is inlined in the template rather than checked out from this repo: `node_modules` is tracked here (9,001 files), so a second checkout would be expensive, and inlining avoids a floating `@master` dependency that would break every repo at once.

## Test Plan

Verified with the script extracted from the rendered YAML, so what ran is what CI will run.

- [x] YAML parses; `bash -n` clean on the extracted `run` block
- [x] **Replays the real bug**: `panoramai@dffbdfd4` (#433) → both rules fire, exit 1
- [x] **Its fix passes**: `panoramai@5864b82f` (#440) → exit 0
- [x] **No false positives on symlink traffic**: 216 symlink-touching commits across 59 repos since 2024 → fires on 4, all genuine defects (a committed virtualenv with `/usr/bin/python3` and `lib64` symlinks; two absolute symlinks into a developer's home; the panoramai case)
- [x] **No false positives on ordinary traffic**: 297 recent commits across mobsuccess, mobsuccess-front, dashboard-data-microservice, lcm-microservice, atlas, airflow-data, dbt-athena, supply-microservice → 0 fires
- [x] Synthetic coverage: root pattern, `dir/*` with a negation, nested `.gitignore`, repo-internal symlink at a hole path, plain file, bare-pattern path (correctly silent)

0 false positives over real history is why this blocks rather than warns — a check you can merge past is no defence against an irreversible loss.

Reviewers: the `if: github.event_name == 'pull_request'` guards matter — this workflow also triggers on `merge_group` and `issue_comment`, where there is no PR head to check out.