### PR TITLE
fix(sample): keep the generated mobsuccess.yml Prettier-clean [FTTECH-12653]

### DIFF
--- a/sample/workflows/mobsuccess.yml
+++ b/sample/workflows/mobsuccess.yml
@@ -116,3 +116,5 @@ jobs:
             exit 1
           fi
           echo "No ignored-directory replacement detected."
+        # Keep a plain scalar last: Prettier requires a blank line between a block scalar and the "# DO NOT EDIT: END" marker appended here.
+        shell: bash


### PR DESCRIPTION
# Why is this needed?

`ms-bot` has merged 11 no-op PRs on `mobsuccess-devops/schemas` in 11 hours (#1010 → #1020), each one a pair of commits that cancel out over a single blank line. About 20 other repos have their sync PR stuck on a failing Prettier check (cognito#957, mobsuccess-app#344, lcm-microservice#1659, core-statistics-microservice#200, …).

The generator in `github-mobsuccess-policy/app/scripts/update-action.sh` (`wrap()`) concatenates this template with `# DO NOT EDIT: END` with nothing in between. Since #156 the template ends on a block scalar (`run: |`), and Prettier requires a blank line between a block scalar and a following column-0 comment — a blank line the generator can never emit. So the bot strips it, CI reformats it back, the merge lands, and an hour later the bot sees the drift again.

The template itself is linted standalone in this repo, where it passes; the assembled file is only ever linted in the consumer repos. This is not a Prettier version gap: 2.2.1 and 3.5.0 both want the same blank line.

The rule is conditional — Prettier wants that blank line after a block scalar and rejects it after a plain scalar — so the generator cannot emit one unconditionally. Ending the last step on a plain scalar (`shell: bash`, the ubuntu default, so a no-op) removes the requirement.

# Testing

- template standalone: `prettier@3.5.0 --check` OK, `prettier@2.2.1 --check` OK
- template + `# DO NOT EDIT: END` appended: `prettier@3.5.0 --check` OK, `prettier@2.2.1 --check` OK
- `npm run prettier` OK, YAML parses, `yaml-lint` OK

# Follow-up

Guard to add in `update-action.sh`: don't open a PR when the only drift is whitespace around the `# DO NOT EDIT: END` marker, so this class of loop can't come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)