### PR TITLE
fix(sample): remove the Prettier workaround from the generated workflow [FTTECH-12653]

### DIFF
--- a/sample/workflows/generated.test.js
+++ b/sample/workflows/generated.test.js
@@ -1,0 +1,40 @@
+const { readdirSync, readFileSync } = require("fs");
+const { join } = require("path");
+const prettier = require("prettier");
+
+// Reproduces wrap() from github-mobsuccess-policy/app/scripts/update-action.sh:
+// the template is inserted between the two markers, with no blank line around them.
+function generate(name, template) {
+  return [
+    "# DO NOT EDIT: BEGIN",
+    "# This snippet has been inserted automatically by mobsuccessbot, do not edit!",
+    `# If changes are needed, update the action ${name} in`,
+    "# https://github.com/mobsuccess-devops/github-mobsuccess-policy",
+    template.replace(/\n$/, ""),
+    "# DO NOT EDIT: END",
+    "",
+  ].join("\n");
+}
+
+describe("generated workflows", () => {
+  const dir = __dirname;
+  const workflows = readdirSync(dir).filter((file) => file.endsWith(".yml"));
+
+  test("there is at least one sample workflow", () => {
+    expect(workflows.length).toBeGreaterThan(0);
+  });
+
+  test.each(workflows)(
+    "%s is Prettier-formatted once the markers are added",
+    (file) => {
+      const name = file.replace(/\.yml$/, "");
+      const template = readFileSync(join(dir, file), "utf-8");
+      const generated = generate(name, template);
+
+      // Consumer repositories lint the generated file, not the template. When
+      // the two disagree, mobsuccessbot and Prettier undo each other on every
+      // sync and the update pull request reopens forever.
+      expect(prettier.format(generated, { parser: "yaml" })).toBe(generated);
+    }
+  );
+});

--- a/sample/workflows/mobsuccess.yml
+++ b/sample/workflows/mobsuccess.yml
@@ -38,9 +38,6 @@ jobs:
 
       - name: Ignored directory replacement
         if: github.event_name == 'pull_request'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -uo pipefail
           fail=0
@@ -116,4 +113,6 @@ jobs:
             exit 1
           fi
           echo "No ignored-directory replacement detected."
-        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/sample/workflows/mobsuccess.yml
+++ b/sample/workflows/mobsuccess.yml
@@ -116,5 +116,4 @@ jobs:
             exit 1
           fi
           echo "No ignored-directory replacement detected."
-        # Keep a plain scalar last: Prettier requires a blank line between a block scalar and the "# DO NOT EDIT: END" marker appended here.
         shell: bash


### PR DESCRIPTION
# Why is this needed?

#161 stopped the loop but paid for it with two things that leaked into ~40 consumer repositories. `mobsuccess-devops/widder#1883` shows what they received:

```yaml
          echo "No ignored-directory replacement detected."
        # Keep a plain scalar last: Prettier requires a blank line between a block scalar and the "# DO NOT EDIT: END" marker appended here.
        shell: bash
 # DO NOT EDIT: END
```

Both lines are wrong to ship. The comment is about Prettier's internals and means nothing in a repository that never sees the generator; it even reads as a contradiction, explaining why a blank line is needed at a spot where there is none. And `shell: bash` does nothing on an ubuntu runner — it is a formatting workaround wearing the costume of CI configuration.

# What this does

Same constraint, nothing added to the workflow:

- `env:` now comes after `run:` in the last step. Key order inside a step is free and execution is identical, so the file simply no longer ends on a block scalar — which is the whole requirement.
- `shell: bash` and the comment are gone.
- `sample/workflows/generated.test.js` rebuilds each sample exactly as `wrap()` does in `github-mobsuccess-policy/app/scripts/update-action.sh` (both markers, no blank line) and asserts the result is Prettier-formatted.

The constraint now lives in this repository's CI, where it belongs, instead of as an unexplained line in every consumer repository.

# Testing

- `npm run test`: 58 passed
- the generated file, with markers, is clean under `prettier@3.5.0` and `prettier@2.2.1`
- negative control: ending the template on the block scalar again fails `mobsuccess.yml is Prettier-formatted once the markers are added`, the other samples stay green
- parsed YAML confirms the step keys are `name, if, run, env` and both `BASE_SHA`/`HEAD_SHA` are still there
- `npm run prettier`, `npm run eslint`: clean

The ~10 sync pull requests already carrying the comment reuse the `mobsuccessbot/workflow-mobsuccess` branch, so mobsuccessbot rewrites them on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)